### PR TITLE
import esm module from parseTree

### DIFF
--- a/language-server/src/jsonc-instance.js
+++ b/language-server/src/jsonc-instance.js
@@ -1,4 +1,4 @@
-import { parseTree } from "jsonc-parser";
+import { parseTree } from "jsonc-parser/lib/esm/main.js";
 import * as JsonPointer from "@hyperjump/json-pointer";
 import { getKeywordId } from "@hyperjump/json-schema/experimental";
 import { drop, find, head, some } from "@hyperjump/pact";

--- a/vscode/src/extension.js
+++ b/vscode/src/extension.js
@@ -21,12 +21,6 @@ const activate = (context) => {
     }
   };
 
-  // Temporary Hack. Get the above code working.
-  // const serverOptions = {
-  //   command: "node",
-  //   args: [context.asAbsolutePath(path.join("..", "language-server", "src", "server.js")), "--stdio"]
-  // };
-
   const clientOptions = {
     documentSelector: [
       { language: "json", pattern: "**/*.schema.json" },

--- a/vscode/src/extension.js
+++ b/vscode/src/extension.js
@@ -1,31 +1,31 @@
 "use strict";
 const path = require("node:path");
-const { LanguageClient } = require("vscode-languageclient/node.js");
+const { LanguageClient, TransportKind } = require("vscode-languageclient/node.js");
 
 
 let client;
 
 const activate = (context) => {
-  // const serverModule = context.asAbsolutePath(path.join("out", "server.js"));
-  // const serverOptions = {
-  //   run: {
-  //     module: serverModule,
-  //     transport: TransportKind.ipc
-  //   },
-  //   debug: {
-  //     module: serverModule,
-  //     transport: TransportKind.ipc,
-  //     options: {
-  //       execArgc: ["--nolazy", "--inspect=6009"]
-  //     }
-  //   }
-  // };
+  const serverModule = context.asAbsolutePath(path.join("out", "server.js"));
+  const serverOptions = {
+    run: {
+      module: serverModule,
+      transport: TransportKind.ipc
+    },
+    debug: {
+      module: serverModule,
+      transport: TransportKind.ipc,
+      options: {
+        execArgc: ["--nolazy", "--inspect=6009"]
+      }
+    }
+  };
 
   // Temporary Hack. Get the above code working.
-  const serverOptions = {
-    command: "node",
-    args: [context.asAbsolutePath(path.join("..", "language-server", "src", "server.js")), "--stdio"]
-  };
+  // const serverOptions = {
+  //   command: "node",
+  //   args: [context.asAbsolutePath(path.join("..", "language-server", "src", "server.js")), "--stdio"]
+  // };
 
   const clientOptions = {
     documentSelector: [


### PR DESCRIPTION
This PR aims to resolve the issue of using a temporary hack to run the language server as we are unable to use the bundled output due to a `MODULE NOT FOUND` error.

**Description:**
The `jsonc-parser` dependency has two module implementations in its library, ESM and UMD. Now, VSCode requires us to bundle the code into a single CommonJS module but the thing is `esbuild` doesn't have a built-in feature for direct UMD to CJS conversion but it does have ESM to CJS. Currently, the import uses the default export of the library which seems to be the UMD module, the solution is to simply change the import to the ESM module instead. 