### PR TITLE
Default dialect when no schema specified

### DIFF
--- a/language-server/src/server.js
+++ b/language-server/src/server.js
@@ -178,7 +178,12 @@ documents.onDidChangeContent(async ({ document }) => {
 const validateSchema = async (document) => {
   const diagnostics = [];
 
-  const settings = await getDocumentSettings(document.uri);
+  let settings = await getDocumentSettings(document.uri);
+  if (!settings) {
+    connection.console.log("Settings not available");
+    settings = {};
+  }
+
   const instance = JsoncInstance.fromTextDocument(document);
   if (instance.typeOf() === "undefined") {
     return;

--- a/language-server/src/server.js
+++ b/language-server/src/server.js
@@ -133,7 +133,7 @@ async function getDocumentSettings(resource) {
     documentSettings.set(resource, result);
   }
 
-  return result;
+  return result ?? {};
 }
 
 let isWorkspaceLoaded = false;
@@ -178,12 +178,7 @@ documents.onDidChangeContent(async ({ document }) => {
 const validateSchema = async (document) => {
   const diagnostics = [];
 
-  let settings = await getDocumentSettings(document.uri);
-  if (!settings) {
-    connection.console.log("Settings not available");
-    settings = {};
-  }
-
+  const settings = await getDocumentSettings(document.uri);
   const instance = JsoncInstance.fromTextDocument(document);
   if (instance.typeOf() === "undefined") {
     return;

--- a/language-server/src/server.js
+++ b/language-server/src/server.js
@@ -46,7 +46,6 @@ connection.onInitialize(({ capabilities, workspaceFolders }) => {
   hasConfigurationCapability = !!(
     capabilities.workspace && !!capabilities.workspace.configuration
   );
-  connection.console.log(hasConfigurationCapability);
 
   if (workspaceFolders) {
     addWorkspaceFolders(workspaceFolders);
@@ -118,8 +117,6 @@ connection.onInitialized(async () => {
 
 const documentSettings = new Map(); // Consider a Map for cache
 let globalSettings = {
-  enableDetailedErrors: false,
-  schemaValidationSeverity: "error",
   defaultDialect: "http://json-schema.org/draft-07/schema#"
 }; // Sensible defaults
 
@@ -226,20 +223,14 @@ const validateSchema = async (document) => {
         }
       }
     }
-
-    connection.sendDiagnostics({ uri: document.uri, diagnostics });
   } catch (error) {
-  // Retrieve the default dialect from settings
     const defaultDialect = settings.defaultDialect;
     dialectUri = defaultDialect;
   }
 
-   // Log the value of the schema used
+
   connection.console.log(`Schema used: ${dialectUri}`);
-  // Use default dialect if none is specified
-  // if (!dialectUri) {
-  //   dialectUri = settings.defaultDialect;
-  // }
+  connection.sendDiagnostics({ uri: document.uri, diagnostics });
 };
 
 // Clear cached document settings when configuration changes

--- a/language-server/src/server.js
+++ b/language-server/src/server.js
@@ -169,7 +169,7 @@ connection.onDidChangeConfiguration((change) => {
   if (hasConfigurationCapability) {
     documentSettings.clear();
   } else {
-    globalSettings = change.settings.jsonSchemaLanguageServer || globalSettings;
+    globalSettings = change.settings.jsonSchemaLanguageServer ?? globalSettings;
   }
 
   validateWorkspace();
@@ -303,13 +303,7 @@ const getTokenBuilder = (uri) => {
 const buildTokens = (builder, document, settings) => {
   const instance = JsoncInstance.fromTextDocument(document);
   const $schema = instance.get("#/$schema");
-  let dialectUri;
-  try {
-    dialectUri = $schema?.value() ?? settings.defaultDialect;
-  } catch (error) {
-    // SKIP
-  }
-
+  const dialectUri = $schema.value ?? settings.defaultDialect;
   const schemaResources = decomposeSchemaDocument(instance, dialectUri);
   for (const { keywordInstance, tokenType, tokenModifier } of getSemanticTokens(schemaResources)) {
     const startPosition = keywordInstance.startPosition();

--- a/language-server/src/server.js
+++ b/language-server/src/server.js
@@ -203,12 +203,10 @@ const validateSchema = async (document) => {
       const $schema = schemaInstance.get("#/$schema");
       if ($schema.typeOf() === "string") {
         diagnostics.push(buildDiagnostic($schema, "Unknown dialect"));
+      } else if (contextDialectUri) {
+        diagnostics.push(buildDiagnostic(schemaInstance, "Unknown dialect"));
       } else {
-        if (contextDialectUri) {
-          diagnostics.push(buildDiagnostic(schemaInstance, "Unknown dialect"));
-        } else {
-          diagnostics.push(buildDiagnostic(schemaInstance, "No dialect"));
-        }
+        diagnostics.push(buildDiagnostic(schemaInstance, "No dialect"));
       }
 
       continue;

--- a/language-server/src/server.js
+++ b/language-server/src/server.js
@@ -160,7 +160,9 @@ async function getDocumentSettings(resource) {
       scopeUri: resource,
       section: "jsonSchemaLanguageServer"
     });
-    documentSettings.set(resource, result);
+    if (result !== null) {
+      documentSettings.set(resource, result);
+    }
   }
 
   return result ?? {};

--- a/language-server/src/server.js
+++ b/language-server/src/server.js
@@ -154,18 +154,15 @@ async function getDocumentSettings(resource) {
     return globalSettings;
   }
 
-  let result = documentSettings.get(resource);
-  if (!result) {
-    result = await connection.workspace.getConfiguration({
+  if (!documentSettings.has(resource)) {
+    const result = await connection.workspace.getConfiguration({
       scopeUri: resource,
       section: "jsonSchemaLanguageServer"
     });
-    if (result !== null) {
-      documentSettings.set(resource, result);
-    }
+    documentSettings.set(resource, result ?? globalSettings);
   }
 
-  return result ?? {};
+  return documentSettings.get(resource);
 }
 
 connection.onDidChangeConfiguration((change) => {

--- a/language-server/src/server.js
+++ b/language-server/src/server.js
@@ -204,7 +204,11 @@ const validateSchema = async (document) => {
       if ($schema.typeOf() === "string") {
         diagnostics.push(buildDiagnostic($schema, "Unknown dialect"));
       } else {
-        diagnostics.push(buildDiagnostic(schemaInstance, "No dialect"));
+        if (contextDialectUri) {
+          diagnostics.push(buildDiagnostic(schemaInstance, "Unknown dialect"));
+        } else {
+          diagnostics.push(buildDiagnostic(schemaInstance, "No dialect"));
+        }
       }
 
       continue;
@@ -303,7 +307,7 @@ const getTokenBuilder = (uri) => {
 const buildTokens = (builder, document, settings) => {
   const instance = JsoncInstance.fromTextDocument(document);
   const $schema = instance.get("#/$schema");
-  const dialectUri = $schema.value ?? settings.defaultDialect;
+  const dialectUri = $schema.value() ?? settings.defaultDialect;
   const schemaResources = decomposeSchemaDocument(instance, dialectUri);
   for (const { keywordInstance, tokenType, tokenModifier } of getSemanticTokens(schemaResources)) {
     const startPosition = keywordInstance.startPosition();

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -31,22 +31,10 @@
   "activationEvents": [
     "onLanguage:json"
   ],
-  "contributes": {
+  "contributes": {                       
     "configuration": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "title": "Configuration for JSON Schema Language Server",
         "properties": {
-          "jsonSchemaLanguageServer.enableDetailedErrors": {
-            "type": "boolean",
-            "description": "Whether to provide additional detail in error messages",
-            "default": true
-          },
-          "jsonSchemaLanguageServer.schemaValidationSeverity": {
-            "type": "string",
-            "enum": ["error", "warning", "information", "hint"],
-            "description": "The severity level to use for schema validation issues",
-            "default": "warning"
-          },
           "jsonSchemaLanguageServer.defaultDialect": {
             "type": "string",
             "description": "The default JSON Schema dialect to use if none is specified in the schema document",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -34,14 +34,13 @@
   "contributes": {                       
     "configuration": {
       "title": "Configuration for JSON Schema Language Server",
-        "properties": {
-          "jsonSchemaLanguageServer.defaultDialect": {
-            "type": "string",
-            "description": "The default JSON Schema dialect to use if none is specified in the schema document",
-            "default": "http://json-schema.org/draft-07/schema#"
-          }
+      "properties": {
+        "jsonSchemaLanguageServer.defaultDialect": {
+          "type": "string",
+          "description": "The default JSON Schema dialect to use if none is specified in the schema document"
         }
       }
     }
   }
+}
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -32,5 +32,28 @@
     "onLanguage:json"
   ],
   "contributes": {
+    "configuration": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "title": "Configuration for JSON Schema Language Server",
+        "properties": {
+          "jsonSchemaLanguageServer.enableDetailedErrors": {
+            "type": "boolean",
+            "description": "Whether to provide additional detail in error messages",
+            "default": true
+          },
+          "jsonSchemaLanguageServer.schemaValidationSeverity": {
+            "type": "string",
+            "enum": ["error", "warning", "information", "hint"],
+            "description": "The severity level to use for schema validation issues",
+            "default": "warning"
+          },
+          "jsonSchemaLanguageServer.defaultDialect": {
+            "type": "string",
+            "description": "The default JSON Schema dialect to use if none is specified in the schema document",
+            "default": "http://json-schema.org/draft-07/schema#"
+          }
+        }
+      }
+    }
   }
-}
+

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -31,7 +31,7 @@
   "activationEvents": [
     "onLanguage:json"
   ],
-  "contributes": {                       
+  "contributes": {
     "configuration": {
       "title": "Configuration for JSON Schema Language Server",
       "properties": {
@@ -43,4 +43,3 @@
     }
   }
 }
-


### PR DESCRIPTION
Resolves #6 #4 

Changes:

- Setup the server to manage configuration. 
- Server now responds to configuration change events from the client.
- Assigns a default dialect when no `$schema` keyword is used.

Video demonstrating the changes:
**VS Code** :


https://github.com/hyperjump-io/json-schema-language-tools/assets/110971977/db53dadc-9388-440c-87dd-4c0ef1191804

**Neovim** :

https://github.com/hyperjump-io/json-schema-language-tools/assets/110971977/14c45890-00ff-484a-9bae-fbcfe3a5f581

Thanks to my partner, @wthrajat ,  for his invaluable assistance throughout our collaboration. His unwavering support, dedication, and assistance in code debugging, guidance in Neovim testing, have significantly enhanced our workflow efficiency and productivity.

**This PR has been created as a part of GSoC qualification task.**
