### PR TITLE
Avoid parsing documents multiple times

### DIFF
--- a/language-server/src/jsonc-instance.js
+++ b/language-server/src/jsonc-instance.js
@@ -164,10 +164,7 @@ export class JsoncInstance {
   }
 
   parent() {
-    const instance = Object.assign(Object.create(Object.getPrototypeOf(this)), this);
-    instance.node = instance.node.parent;
-
-    return instance;
+    return new JsoncInstance(this.textDocument, this.root, this.node.parent, this.pointer, this.annotations);
   }
 
   startPosition() {


### PR DESCRIPTION
Resolves #30 

Parsing `TextDocument`s into `JsoncInstance` instances is necessary for most language server features. The more features we add, the more times we will be parsing documents. Centralizing this functionality allows us to cache the result when possible, but also allows us to reduce some code duplication.

From now on, all code should use the `getSchemaResources` function instead of calling `JsoncInstance.fromTextDocument`.