### PR TITLE
[package.json][scripts]: Add post install script to the root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "JSON Schema Language Tools",
   "type": "module",
+  "scripts": {
+    "postinstall": "cd vscode && npm install && cd ../language-server && npm install && cd .."
+  },
   "author": "Jason Desrosiers <jdesrosi@gmail.com>",
   "license": "MIT",
   "repository": "github:hyperjump-io/json-schema-language-tools",


### PR DESCRIPTION
**Description:**
This PR aims to add a script to the root `package.json` to centralise `npm install` so that we don't have to manually go into each directory.