### PR TITLE
Config to define files to be treated as JSON Schema files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "eslint-import-resolver-node": "*",
         "eslint-plugin-import": "*",
         "json-schema-test-suite": "github:json-schema-org/JSON-Schema-Test-Suite",
+        "picomatch": "*",
         "vitest": "*"
       }
     },
@@ -3327,6 +3328,18 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/pkg-types": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "eslint-import-resolver-node": "*",
     "eslint-plugin-import": "*",
     "json-schema-test-suite": "github:json-schema-org/JSON-Schema-Test-Suite",
-    "vitest": "*"
+    "vitest": "*",
+    "picomatch": "*"
   },
   "dependencies": {
     "@hyperjump/browser": "^1.1.0",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -38,6 +38,11 @@
         "jsonSchemaLanguageServer.defaultDialect": {
           "type": "string",
           "description": "The default JSON Schema dialect to use if none is specified in the schema document"
+        },
+        "jsonSchemaLanguageServer.schemaFilePatterns": {
+          "type": "array",
+          "description": "The glob pattern for identifying JSON Schema files.",
+          "default": ["**/*.schema.json", "**/schema.json"]
         }
       }
     }


### PR DESCRIPTION
Resolves #5 

Changes:
-The user can now define the files to be watched, the default behavior is to watch all files.

Tested in both VSCode and Neovim.

![image](https://github.com/hyperjump-io/json-schema-language-tools/assets/110971977/a00b942e-e843-4c67-ae6d-83186613414b)

![WhatsApp Image 2024-05-11 at 01 44 33_cae6d68c](https://github.com/hyperjump-io/json-schema-language-tools/assets/110971977/fd74a678-029a-483c-842a-0bd532a9af6a)

