### PR TITLE
Config for files to be treated as JSON Schema files

### DIFF
--- a/language-server/src/features/document-settings.js
+++ b/language-server/src/features/document-settings.js
@@ -3,8 +3,6 @@ import { publish } from "../pubsub.js";
 import { clearSchemaDocuments } from "./schema-documents.js";
 
 
-export let schemaFilePatterns = ["**/*.schema.json", "**/schema.json"];
-
 let hasConfigurationCapability = false;
 let hasDidChangeConfigurationCapability = false;
 
@@ -28,7 +26,6 @@ export default {
       } else {
         globalSettings = change.settings.jsonSchemaLanguageServer ?? globalSettings;
       }
-      schemaFilePatterns = globalSettings.schemaFilePatterns ?? defaultFilePatterns;
 
       publish("workspaceChanged", { changes: [] });
     });
@@ -40,7 +37,6 @@ export default {
 };
 
 const documentSettings = new Map();
-const defaultFilePatterns = ["**/*.schema.json", "**/schema.json"];
 let globalSettings = {};
 
 export const getDocumentSettings = async (connection, uri) => {
@@ -53,7 +49,6 @@ export const getDocumentSettings = async (connection, uri) => {
       scopeUri: uri,
       section: "jsonSchemaLanguageServer"
     });
-    schemaFilePatterns = result?.schemaFilePatterns ?? defaultFilePatterns;
     documentSettings.set(uri, result ?? globalSettings);
   }
 

--- a/language-server/src/features/document-settings.js
+++ b/language-server/src/features/document-settings.js
@@ -6,12 +6,14 @@ import picomatch from "picomatch";
 export const isSchema = RegExp.prototype.test.bind(/(?:\.|\/|^)schema\.json$/);
 export let schemaFilePatterns = ["**/*.schema.json", "**/schema.json"];
 export const isMatchedFile = (uri, patterns) => {
-  const matchers = patterns.map((pattern) => picomatch(pattern, {
-    noglobstar: false,
-    matchBase: true,
-    dot: true,
-    nonegate: true
-  }));
+  const matchers = patterns.map((pattern) => {
+    return picomatch(pattern, {
+      noglobstar: false,
+      matchBase: false,
+      dot: true,
+      nonegate: true
+    });
+  });
   return matchers.some((matcher) => matcher(uri));
 };
 

--- a/language-server/src/features/document-settings.js
+++ b/language-server/src/features/document-settings.js
@@ -1,21 +1,9 @@
 import { DidChangeConfigurationNotification } from "vscode-languageserver";
 import { publish } from "../pubsub.js";
-import picomatch from "picomatch";
 
 
 export const isSchema = RegExp.prototype.test.bind(/(?:\.|\/|^)schema\.json$/);
 export let schemaFilePatterns = ["**/*.schema.json", "**/schema.json"];
-export const isMatchedFile = (uri, patterns) => {
-  const matchers = patterns.map((pattern) => {
-    return picomatch(pattern, {
-      noglobstar: false,
-      matchBase: false,
-      dot: true,
-      nonegate: true
-    });
-  });
-  return matchers.some((matcher) => matcher(uri));
-};
 
 let hasConfigurationCapability = false;
 let hasDidChangeConfigurationCapability = false;
@@ -39,7 +27,7 @@ export default {
       } else {
         globalSettings = change.settings.jsonSchemaLanguageServer ?? globalSettings;
       }
-      schemaFilePatterns = globalSettings.schemaFilePatterns ?? ["**/*.schema.json", "**/schema.json"];
+      schemaFilePatterns = globalSettings.schemaFilePatterns ?? defaultFilePatterns;
 
       publish("workspaceChange", { changes: [] });
     });
@@ -51,6 +39,7 @@ export default {
 };
 
 const documentSettings = new Map();
+const defaultFilePatterns = ["**/*.schema.json", "**/schema.json"];
 let globalSettings = {};
 
 export const getDocumentSettings = async (connection, uri) => {
@@ -63,7 +52,7 @@ export const getDocumentSettings = async (connection, uri) => {
       scopeUri: uri,
       section: "jsonSchemaLanguageServer"
     });
-    schemaFilePatterns = result?.schemaFilePatterns ?? ["**/*.schema.json", "**/schema.json"];
+    schemaFilePatterns = result?.schemaFilePatterns ?? defaultFilePatterns;
     documentSettings.set(uri, result ?? globalSettings);
   }
 

--- a/language-server/src/features/document-settings.js
+++ b/language-server/src/features/document-settings.js
@@ -19,12 +19,10 @@ export default {
       connection.client.register(DidChangeConfigurationNotification.type);
     }
 
-    connection.onDidChangeConfiguration((change) => {
+    connection.onDidChangeConfiguration(() => {
       if (hasConfigurationCapability) {
         documentSettings.clear();
         clearSchemaDocuments();
-      } else {
-        globalSettings = change.settings.jsonSchemaLanguageServer ?? globalSettings;
       }
 
       publish("workspaceChanged", { changes: [] });
@@ -37,11 +35,13 @@ export default {
 };
 
 const documentSettings = new Map();
-let globalSettings = {};
+const defaultSettings = {
+  schemaFilePatterns: ["**/*.schema.json", "**/schema.json"]
+};
 
 export const getDocumentSettings = async (connection, uri) => {
   if (!hasConfigurationCapability) {
-    return globalSettings;
+    return defaultSettings;
   }
 
   if (!documentSettings.has(uri)) {
@@ -49,7 +49,7 @@ export const getDocumentSettings = async (connection, uri) => {
       scopeUri: uri,
       section: "jsonSchemaLanguageServer"
     });
-    documentSettings.set(uri, result ?? globalSettings);
+    documentSettings.set(uri, result ?? defaultSettings);
   }
 
   return documentSettings.get(uri);

--- a/language-server/src/features/document-settings.js
+++ b/language-server/src/features/document-settings.js
@@ -48,8 +48,8 @@ export const getDocumentSettings = async (connection, uri) => {
     const result = await connection.workspace.getConfiguration({
       scopeUri: uri,
       section: "jsonSchemaLanguageServer"
-    });
-    documentSettings.set(uri, result ?? defaultSettings);
+    }) ?? {};
+    documentSettings.set(uri, { ...defaultSettings, ...result });
   }
 
   return documentSettings.get(uri);

--- a/language-server/src/features/document-settings.js
+++ b/language-server/src/features/document-settings.js
@@ -2,7 +2,6 @@ import { DidChangeConfigurationNotification } from "vscode-languageserver";
 import { publish } from "../pubsub.js";
 
 
-export const isSchema = RegExp.prototype.test.bind(/(?:\.|\/|^)schema\.json$/);
 export let schemaFilePatterns = ["**/*.schema.json", "**/schema.json"];
 
 let hasConfigurationCapability = false;

--- a/language-server/src/features/semantic-tokens.js
+++ b/language-server/src/features/semantic-tokens.js
@@ -3,7 +3,8 @@ import { getKeywordId } from "@hyperjump/json-schema/experimental";
 import * as Instance from "../json-instance.js";
 import { getSchemaDocument } from "./schema-documents.js";
 import { toAbsoluteUri } from "../util.js";
-import { isSchema } from "./document-settings.js";
+import { schemaFilePatterns } from "./document-settings.js";
+import { isMatchedFile } from "./workspace.js";
 
 
 export default {
@@ -51,7 +52,7 @@ export default {
     };
 
     connection.languages.semanticTokens.on(async ({ textDocument }) => {
-      if (!isSchema(textDocument.uri)) {
+      if (!isMatchedFile(textDocument.uri, schemaFilePatterns)) {
         return { data: [] };
       }
 

--- a/language-server/src/features/semantic-tokens.js
+++ b/language-server/src/features/semantic-tokens.js
@@ -5,6 +5,7 @@ import { getSchemaDocument } from "./schema-documents.js";
 import { toAbsoluteUri } from "../util.js";
 import { schemaFilePatterns } from "./document-settings.js";
 import { isMatchedFile } from "./workspace.js";
+import { fileURLToPath } from "node:url";
 
 
 export default {
@@ -52,7 +53,8 @@ export default {
     };
 
     connection.languages.semanticTokens.on(async ({ textDocument }) => {
-      if (!isMatchedFile(textDocument.uri, schemaFilePatterns)) {
+      const filePath = fileURLToPath(textDocument.uri);
+      if (!isMatchedFile(filePath, schemaFilePatterns)) {
         return { data: [] };
       }
 

--- a/language-server/src/features/semantic-tokens.js
+++ b/language-server/src/features/semantic-tokens.js
@@ -3,9 +3,9 @@ import { getKeywordId } from "@hyperjump/json-schema/experimental";
 import * as Instance from "../json-instance.js";
 import { getSchemaDocument } from "./schema-documents.js";
 import { toAbsoluteUri } from "../util.js";
-import { schemaFilePatterns } from "./document-settings.js";
 import { isMatchedFile } from "./workspace.js";
 import { fileURLToPath } from "node:url";
+import { getDocumentSettings } from "./document-settings.js";
 
 
 export default {
@@ -54,6 +54,8 @@ export default {
 
     connection.languages.semanticTokens.on(async ({ textDocument }) => {
       const filePath = fileURLToPath(textDocument.uri);
+      const settings = await getDocumentSettings(connection);
+      const schemaFilePatterns = settings.schemaFilePatterns;
       if (!isMatchedFile(filePath, schemaFilePatterns)) {
         return { data: [] };
       }

--- a/language-server/src/features/workspace.js
+++ b/language-server/src/features/workspace.js
@@ -11,8 +11,21 @@ import {
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { publishAsync } from "../pubsub.js";
 import { getSchemaDocument } from "./schema-documents.js";
-import { getDocumentSettings, isMatchedFile } from "./document-settings.js";
+import { getDocumentSettings } from "./document-settings.js";
+import picomatch from "picomatch";
 
+
+const isMatchedFile = (uri, patterns) => {
+  const matchers = patterns.map((pattern) => {
+    return picomatch(pattern, {
+      noglobstar: false,
+      matchBase: false,
+      dot: true,
+      nonegate: true
+    });
+  });
+  return matchers.some((matcher) => matcher(uri));
+};
 
 let hasWorkspaceFolderCapability = false;
 let hasWorkspaceWatchCapability = false;

--- a/language-server/src/features/workspace.js
+++ b/language-server/src/features/workspace.js
@@ -15,7 +15,7 @@ import { getDocumentSettings } from "./document-settings.js";
 import picomatch from "picomatch";
 
 
-const isMatchedFile = (uri, patterns) => {
+export const isMatchedFile = (uri, patterns) => {
   const matchers = patterns.map((pattern) => {
     return picomatch(pattern, {
       noglobstar: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "@hyperjump/json-pointer": "^1.0.1",
         "@hyperjump/json-schema": "github:hyperjump-io/json-schema#lsp",
         "@hyperjump/pact": "^1.3.0",
-        "@hyperjump/uri": "^1.2.2"
+        "@hyperjump/uri": "^1.2.2",
+        "picomatch": "^4.0.2"
       },
       "devDependencies": {
         "@vitest/coverage-v8": "*",
@@ -3312,6 +3313,17 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/pkg-types": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@hyperjump/json-pointer": "^1.0.1",
     "@hyperjump/json-schema": "github:hyperjump-io/json-schema#lsp",
     "@hyperjump/pact": "^1.3.0",
-    "@hyperjump/uri": "^1.2.2"
+    "@hyperjump/uri": "^1.2.2",
+    "picomatch": "^4.0.2"
   }
 }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -38,6 +38,11 @@
         "jsonSchemaLanguageServer.defaultDialect": {
           "type": "string",
           "description": "The default JSON Schema dialect to use if none is specified in the schema document"
+        },
+        "jsonSchemaLanguageServer.schemaFilePatterns": {
+          "type": "array",
+          "description": "The glob pattern for identifying JSON Schema files.",
+          "default": ["**/*.schema.json", "**/schema.json"]
         }
       }
     }


### PR DESCRIPTION
Resolves: #5 

-Config for files to be treated as JSON Schema files
-Semantic tokens are built only for files watched.
-Not all files are watched at initial workspace validation but only user-defined files. 




https://github.com/hyperjump-io/json-schema-language-tools/assets/110971977/8ad222df-4560-400c-b8ab-c7c0e8ad6d4c


https://github.com/hyperjump-io/json-schema-language-tools/assets/110971977/d270ce9a-766a-42cd-8451-18b613adfc28



