### PR TITLE
Completion of if/then patterns for every if nested in blocks

### DIFF
--- a/language-server/src/features/if-then-completion.js
+++ b/language-server/src/features/if-then-completion.js
@@ -1,4 +1,5 @@
 import { CompletionItemKind } from "vscode-languageserver";
+import * as SchemaDocument from "../schema-document.js";
 import { subscribe } from "../pubsub.js";
 
 
@@ -8,61 +9,63 @@ export default {
   },
 
   onInitialized() {
-    subscribe("completions", async (_message, { document, offset, completions }) => {
-      const text = document.getText();
-      const startOfLine = text.lastIndexOf("\n", offset - 1) + 1;
-      const textBeforePosition = text.slice(startOfLine, offset);
-      if (textBeforePosition.trim().endsWith("\"if\":")) {
-        completions.push(...ifThenPatternCompletion());
+    subscribe("completions", async (_message, { schemaDocument, offset, completions }) => {
+      const currentProperty = SchemaDocument.findNodeAtOffset(schemaDocument, offset);
+      if (currentProperty && currentProperty.pointer.endsWith("/if")) {
+        completions.push(...ifThenPatternCompletion);
       }
+
+      // const text = document.getText();
+      // const startOfLine = text.lastIndexOf("\n", offset - 1) + 1;
+      // const textBeforePosition = text.slice(startOfLine, offset);
+      // if (textBeforePosition.trim().endsWith("\"if\":")) {
+      //   completions.push(...ifThenPatternCompletion());
+      // }
     });
   }
 };
 
-function ifThenPatternCompletion() {
-  return [
-    {
-      label: "if/then",
-      kind: CompletionItemKind.Snippet,
-      insertText: `{
-          "type": "object",
-          "properties": {
-            "{varName}": { "const": "{value}" }
-          },
-          "required": ["{varName}"]
-        },
-        
-        "then": {
-        }`,
-      documentation: "Basic if/then pattern with a single condition and corresponding schema."
+const ifThenPatternCompletion = [
+  {
+    label: "if/then",
+    kind: CompletionItemKind.Snippet,
+    insertText: `{
+      "type": "object",
+      "properties": {
+        "{varName}": { "const": "{value}" }
+      },
+      "required": ["{varName}"]
     },
-    {
-      label: "If/then/else",
-      kind: CompletionItemKind.Snippet,
-      insertText: `{
-           "type": "object",
-           "properties": {
-            "{varName}": { "const": "{value}" }
-          },
-          "required": ["{varName}"]
-         },
-         "then": {
-         },
-         "else": {
-         }`,
-      documentation: "Conditional object structure with if/then/else logic"
+    "then": {
+    }`,
+    documentation: "Basic if/then pattern with a single condition and corresponding schema."
+  },
+  {
+    label: "If/then/else",
+    kind: CompletionItemKind.Snippet,
+    insertText: `{
+      "type": "object",
+      "properties": {
+        "{varName}": { "const": "{value}" }
+      },
+      "required": ["{varName}"]
     },
-    {
-      label: "true",
-      kind: CompletionItemKind.Snippet,
-      insertText: `true`,
-      documentation: "if true"
+    "then": {
     },
-    {
-      label: "false",
-      kind: CompletionItemKind.Snippet,
-      insertText: `false`,
-      documentation: "if false"
-    }
-  ];
-}
+    "else": {
+    }`,
+    documentation: "Conditional object structure with if/then/else logic"
+  },
+  {
+    label: "true",
+    kind: CompletionItemKind.Snippet,
+    insertText: `true`,
+    documentation: "if true"
+  },
+  {
+    label: "false",
+    kind: CompletionItemKind.Snippet,
+    insertText: `false`,
+    documentation: "if false"
+  }
+];

--- a/language-server/src/features/if-then-completion.js
+++ b/language-server/src/features/if-then-completion.js
@@ -1,4 +1,4 @@
-import { CompletionItemKind } from "vscode-languageserver";
+import { CompletionItemKind, InsertTextFormat } from "vscode-languageserver";
 import * as SchemaDocument from "../schema-document.js";
 import { subscribe } from "../pubsub.js";
 
@@ -14,13 +14,6 @@ export default {
       if (currentProperty && currentProperty.pointer.endsWith("/if")) {
         completions.push(...ifThenPatternCompletion);
       }
-
-      // const text = document.getText();
-      // const startOfLine = text.lastIndexOf("\n", offset - 1) + 1;
-      // const textBeforePosition = text.slice(startOfLine, offset);
-      // if (textBeforePosition.trim().endsWith("\"if\":")) {
-      //   completions.push(...ifThenPatternCompletion());
-      // }
     });
   }
 };
@@ -30,30 +23,29 @@ const ifThenPatternCompletion = [
     label: "if/then",
     kind: CompletionItemKind.Snippet,
     insertText: `{
-      "type": "object",
-      "properties": {
-        "{varName}": { "const": "{value}" }
-      },
-      "required": ["{varName}"]
-    },
-    "then": {
-    }`,
+  "type": "object",
+  "properties": {
+    "\${1:propertyName}": { "const": \${2:value} }
+  },
+  "required": ["\${1:propertyName}"]
+},
+"then": \${3:{}}`,
+    insertTextFormat: InsertTextFormat.Snippet,
     documentation: "Basic if/then pattern with a single condition and corresponding schema."
   },
   {
     label: "If/then/else",
     kind: CompletionItemKind.Snippet,
     insertText: `{
-      "type": "object",
-      "properties": {
-        "{varName}": { "const": "{value}" }
-      },
-      "required": ["{varName}"]
-    },
-    "then": {
-    },
-    "else": {
-    }`,
+  "type": "object",
+  "properties": {
+    "\${1:varName}": { "const": \${2:value} }
+  },
+  "required": ["\${1:varName}"]
+},
+"then": \${3:{}},
+"else": \${4:{}}`,
+    insertTextFormat: InsertTextFormat.Snippet,
     documentation: "Conditional object structure with if/then/else logic"
   },
   {

--- a/language-server/src/features/if-then-completion.js
+++ b/language-server/src/features/if-then-completion.js
@@ -47,17 +47,5 @@ const ifThenPatternCompletion = [
 "else": \${4:{}}`,
     insertTextFormat: InsertTextFormat.Snippet,
     documentation: "Conditional object structure with if/then/else logic"
-  },
-  {
-    label: "true",
-    kind: CompletionItemKind.Snippet,
-    insertText: `true`,
-    documentation: "if true"
-  },
-  {
-    label: "false",
-    kind: CompletionItemKind.Snippet,
-    insertText: `false`,
-    documentation: "if false"
   }
 ];

--- a/language-server/src/features/if-then-completion.js
+++ b/language-server/src/features/if-then-completion.js
@@ -1,0 +1,68 @@
+import { CompletionItemKind } from "vscode-languageserver";
+import { subscribe } from "../pubsub.js";
+
+
+export default {
+  onInitialize() {
+    return {};
+  },
+
+  onInitialized() {
+    subscribe("completions", async (_message, { document, offset, completions }) => {
+      const text = document.getText();
+      const startOfLine = text.lastIndexOf("\n", offset - 1) + 1;
+      const textBeforePosition = text.slice(startOfLine, offset);
+      if (textBeforePosition.trim().endsWith("\"if\":")) {
+        completions.push(...ifThenPatternCompletion());
+      }
+    });
+  }
+};
+
+function ifThenPatternCompletion() {
+  return [
+    {
+      label: "if/then",
+      kind: CompletionItemKind.Snippet,
+      insertText: `{
+          "type": "object",
+          "properties": {
+            "{varName}": { "const": "{value}" }
+          },
+          "required": ["{varName}"]
+        },
+        
+        "then": {
+        }`,
+      documentation: "Basic if/then pattern with a single condition and corresponding schema."
+    },
+    {
+      label: "If/then/else",
+      kind: CompletionItemKind.Snippet,
+      insertText: `{
+           "type": "object",
+           "properties": {
+            "{varName}": { "const": "{value}" }
+          },
+          "required": ["{varName}"]
+         },
+         "then": {
+         },
+         "else": {
+         }`,
+      documentation: "Conditional object structure with if/then/else logic"
+    },
+    {
+      label: "true",
+      kind: CompletionItemKind.Snippet,
+      insertText: `true`,
+      documentation: "if true"
+    },
+    {
+      label: "false",
+      kind: CompletionItemKind.Snippet,
+      insertText: `false`,
+      documentation: "if false"
+    }
+  ];
+}

--- a/language-server/src/server.js
+++ b/language-server/src/server.js
@@ -17,6 +17,7 @@ import semanticTokensFeature from "./features/semantic-tokens.js";
 import validationErrorsFeature from "./features/validation-errors.js";
 import deprecatedFeature from "./features/deprecated.js";
 import completionFeature from "./features/completion.js";
+import ifThenCompletionFeature from "./features/if-then-completion.js";
 import schemaCompletion from "./features/schema-completion.js";
 import hoverFeature from "./features/hover.js";
 
@@ -34,6 +35,7 @@ const features = [
   deprecatedFeature,
   completionFeature,
   schemaCompletion,
+  ifThenCompletionFeature,
   hoverFeature,
   workspaceFeature // Workspace must be last
 ];


### PR DESCRIPTION
Resolves #12 

using `currentProperty` does not for now recognize "if" in nested blocks. So, the current approach could be changed accordingly which identifies "if" at all positions.

![image](https://github.com/hyperjump-io/json-schema-language-tools/assets/110971977/76ae0861-d496-4d94-bb98-1a58da334b16)
![WhatsApp Image 2024-06-01 at 15 01 59_645d4a0f](https://github.com/hyperjump-io/json-schema-language-tools/assets/110971977/c9136c43-5714-43fe-9853-d4e91ee0f5a4)
