### PR TITLE
Validate schema references

### DIFF
--- a/language-server/README.md
+++ b/language-server/README.md
@@ -3,10 +3,11 @@
 A Language Server for JSON Schema development.
 
 Features:
+* Full support for draft-04/06/07/2019-09/2020-12
 * Inline diagnostics for invalid schemas
 * Semantic highlighting of JSON Schema keywords
 * Semantic highlighting of deprecated keywords
-* Full support for draft-04/06/07/2019-09/2020-12
+* Inline diagnostics for invalid references
 
 ## Settings
 

--- a/language-server/src/features/schema-registry.js
+++ b/language-server/src/features/schema-registry.js
@@ -36,3 +36,13 @@ export const allSchemaDocuments = function* () {
     yield schemaDocument;
   }
 };
+
+export const getSchemaResource = (schemaUri) => {
+  for (const schemaDocument of allSchemaDocuments()) {
+    for (const schemaResource of schemaDocument.schemaResources) {
+      if (schemaResource.baseUri === schemaUri) {
+        return schemaResource;
+      }
+    }
+  }
+};

--- a/language-server/src/features/validate-references.js
+++ b/language-server/src/features/validate-references.js
@@ -1,0 +1,38 @@
+import { getKeywordName } from "@hyperjump/json-schema/experimental";
+import * as SchemaNode from "../schema-node.js";
+import { subscribe } from "../pubsub.js";
+
+
+export default {
+  onInitialize() {
+    return {};
+  },
+
+  onInitialized() {
+    subscribe("diagnostics", async (_message, { schemaDocument, diagnostics }) => {
+      for (const schemaResource of schemaDocument.schemaResources) {
+        for (const node of references(schemaResource)) {
+          const reference = SchemaNode.value(node);
+          const referencedSchema = SchemaNode.get(reference, schemaResource);
+          if (!referencedSchema) {
+            diagnostics.push({ instance: node, message: "Referenced schema doesn't exist" });
+          }
+        }
+      }
+    });
+  }
+};
+
+const references = function* (schemaResource) {
+  const refToken = getKeywordName(schemaResource.dialectUri, "https://json-schema.org/keyword/ref");
+  const legacyRefToken = getKeywordName(schemaResource.dialectUri, "https://json-schema.org/keyword/draft-04/ref");
+
+  for (const node of SchemaNode.allNodes(schemaResource)) {
+    if (node.parent && SchemaNode.typeOf(node.parent) === "property") {
+      const keyword = SchemaNode.value(node.parent.children[0]);
+      if (keyword === refToken || keyword === legacyRefToken) {
+        yield node;
+      }
+    }
+  }
+};

--- a/language-server/src/schema-node.js
+++ b/language-server/src/schema-node.js
@@ -1,4 +1,9 @@
+import * as JsonPointer from "@hyperjump/json-pointer";
+import { reduce } from "@hyperjump/pact";
+import { resolveIri } from "@hyperjump/uri";
 import * as JsonNode from "./json-node.js";
+import { getSchemaResource } from "./features/schema-registry.js";
+import { toAbsoluteUri, uriFragment } from "./util.js";
 
 
 // eslint-disable-next-line import/export
@@ -8,6 +13,26 @@ export const cons = (uri, pointer, value, type, children, parent, offset, textLe
   node.anchors = anchors;
 
   return node;
+};
+
+// eslint-disable-next-line import/export
+export const get = (uri, node) => {
+  const schemaId = toAbsoluteUri(resolveIri(uri, node?.baseUri));
+  const schemaResource = getSchemaResource(schemaId);
+  if (!schemaResource) {
+    return;
+  }
+
+  const fragment = uriFragment(uri);
+  const pointer = fragment === "" || fragment[0] === "/" ? fragment : node.anchors[fragment];
+  if (typeof pointer !== "string") {
+    return;
+  }
+
+  return reduce((node, segment) => {
+    segment = segment === "-" && JsonNode.typeOf(node) === "array" ? JsonNode.length(node) : segment;
+    return JsonNode.step(segment, node);
+  }, schemaResource, JsonPointer.pointerSegments(pointer));
 };
 
 // eslint-disable-next-line import/export

--- a/language-server/src/server.js
+++ b/language-server/src/server.js
@@ -15,6 +15,7 @@ import schemaRegistryFeature from "./features/schema-registry.js";
 import workspaceFeature from "./features/workspace.js";
 import semanticTokensFeature from "./features/semantic-tokens.js";
 import validationErrorsFeature from "./features/validation-errors.js";
+import validateReferencesFeature from "./features/validate-references.js";
 import deprecatedFeature from "./features/deprecated.js";
 import completionFeature from "./features/completion.js";
 import schemaCompletion from "./features/schema-completion.js";
@@ -31,6 +32,7 @@ const features = [
   schemaRegistryFeature,
   semanticTokensFeature,
   validationErrorsFeature,
+  validateReferencesFeature,
   deprecatedFeature,
   completionFeature,
   schemaCompletion,


### PR DESCRIPTION
Resolves #7

Adds support for validating references in a schema. It handles references that are local (`#/$defs/foo`), external, (`another-schema`), and both external and local (`another-schema#/$defs/foo`).