### PR TITLE
Tests for document settings

### DIFF
--- a/language-server/src/features/document-settings.test.js
+++ b/language-server/src/features/document-settings.test.js
@@ -1,0 +1,130 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { ConfigurationRequest, DidChangeTextDocumentNotification, PublishDiagnosticsNotification } from "vscode-languageserver/node";
+import {
+  getTestClient,
+  closeDocument,
+  initializeServer,
+  openDocument
+} from "../test-utils.js";
+import documentSettings from "./document-settings.js";
+import schemaRegistry from "./schema-registry.js";
+import workspace from "./workspace.js";
+import validationErrorsFeature from "./validation-errors.js";
+
+
+describe("Feature - Document Settings", () => {
+  let client;
+  let documentUri;
+
+  beforeAll(async () => {
+    client = getTestClient([
+      workspace,
+      documentSettings,
+      schemaRegistry,
+      validationErrorsFeature
+    ]);
+    const init = {};
+    const settings = { "defaultDialect": "https://json-schema.org/draft/2020-12/schema" };
+    await initializeServer(client, init, settings);
+  });
+
+  afterAll(async () => {
+    await closeDocument(client, documentUri);
+  });
+
+  test("test default dialect", async () => {
+    documentUri = "file:///path/to/workspace/subjectA.schema.json";
+    await openDocument(client, documentUri, `{}`);
+
+    const diagnosticsPromise = new Promise((resolve) => {
+      client.onNotification(PublishDiagnosticsNotification, (params) => {
+        resolve(params.diagnostics);
+      });
+    });
+
+    const params = {
+      textDocument: { uri: documentUri },
+      contentChanges: []
+    };
+
+    await client.sendNotification(DidChangeTextDocumentNotification, params);
+
+    const diagnostics = await diagnosticsPromise;
+    expect(diagnostics).to.eql([]);
+  });
+
+  test("test no dialect", async () => {
+    documentUri = "file:///path/to/workspace/subjectB.schema.json";
+    await openDocument(client, documentUri, `{}`);
+
+    await client.onRequest(ConfigurationRequest, () => {
+      return [{}];
+    });
+
+    const diagnosticsPromise = new Promise((resolve) => {
+      client.onNotification(PublishDiagnosticsNotification, (params) => {
+        resolve(params.diagnostics);
+      });
+    });
+
+    const params = {
+      textDocument: { uri: documentUri },
+      contentChanges: []
+    };
+
+    await client.sendNotification(DidChangeTextDocumentNotification, params);
+
+    const diagnostics = await diagnosticsPromise;
+    expect(diagnostics[0].message).to.eql("No dialect");
+  });
+
+  test("test unknown dialect", async () => {
+    documentUri = "file:///path/to/workspace/subjectC.schema.json";
+    await openDocument(client, documentUri, `{"$schema":""}`);
+
+    await client.onRequest(ConfigurationRequest, () => {
+      return [{}];
+    });
+
+    const diagnosticsPromise = new Promise((resolve) => {
+      client.onNotification(PublishDiagnosticsNotification, (params) => {
+        resolve(params.diagnostics);
+      });
+    });
+
+    const params = {
+      textDocument: { uri: documentUri },
+      contentChanges: []
+    };
+
+    await client.sendNotification(DidChangeTextDocumentNotification, params);
+
+    const diagnostics = await diagnosticsPromise;
+    expect(diagnostics[0].message).to.eql("Unknown dialect");
+  });
+
+  test("test unknown dialect when default dialect is unknown", async () => {
+    documentUri = "file:///path/to/workspace/subjectD.schema.json";
+    await openDocument(client, documentUri, `{}`);
+
+    await client.onRequest(ConfigurationRequest, () => {
+      return [{ "defaultDialect": "" }];
+    });
+
+    const diagnosticsPromise = new Promise((resolve) => {
+      client.onNotification(PublishDiagnosticsNotification, (params) => {
+        resolve(params.diagnostics);
+      });
+    });
+
+    const params = {
+      textDocument: { uri: documentUri },
+      contentChanges: []
+    };
+
+    await client.sendNotification(DidChangeTextDocumentNotification, params);
+
+    const diagnostics = await diagnosticsPromise;
+    expect(diagnostics[0].message).to.eql("Unknown dialect");
+  });
+});

--- a/language-server/src/features/if-then-completion.test.js
+++ b/language-server/src/features/if-then-completion.test.js
@@ -14,7 +14,7 @@ describe("Feature - if/then completion", () => {
   });
 
   test("if/then completion with colon", async () => {
-    const documentUri = "file://path/to/workspace/subject1.schema.json";
+    const documentUri = "file:///path/to/workspace/subject1.schema.json";
     await openDocument(client, documentUri, `{
   "if":
 }`);
@@ -36,7 +36,7 @@ describe("Feature - if/then completion", () => {
   });
 
   test("if/then completion with space", async () => {
-    const documentUri = "file://path/to/workspace/subject2.schema.json";
+    const documentUri = "file:///path/to/workspace/subject2.schema.json";
     await openDocument(client, documentUri, `{
   "if": 
 }`);
@@ -58,7 +58,7 @@ describe("Feature - if/then completion", () => {
   });
 
   test("if/then completion on property key", async () => {
-    const documentUri = "file://path/to/workspace/subject3.schema.json";
+    const documentUri = "file:///path/to/workspace/subject3.schema.json";
     await openDocument(client, documentUri, `{
   "if":
 }`);
@@ -80,7 +80,7 @@ describe("Feature - if/then completion", () => {
   });
 
   test("if/then completion on property value", async () => {
-    const documentUri = "file://path/to/workspace/subject4.schema.json";
+    const documentUri = "file:///path/to/workspace/subject4.schema.json";
     await openDocument(client, documentUri, `{
   "if": ""
 }`);
@@ -102,7 +102,7 @@ describe("Feature - if/then completion", () => {
   });
 
   test("if/then completion without colon", async () => {
-    const documentUri = "file://path/to/workspace/subject5.schema.json";
+    const documentUri = "file:///path/to/workspace/subject5.schema.json";
     await openDocument(client, documentUri, `{
   "if"
 }`);

--- a/language-server/src/features/schema-completion.test.js
+++ b/language-server/src/features/schema-completion.test.js
@@ -14,7 +14,7 @@ describe("Feature - $schema completion", () => {
   });
 
   test("$schema completion with string", async () => {
-    const documentUri = "file://path/to/workspace/subject1.schema.json";
+    const documentUri = "file:///path/to/workspace/subject1.schema.json";
     await openDocument(client, documentUri, `{
   "$schema": ""
 }`);
@@ -35,7 +35,7 @@ describe("Feature - $schema completion", () => {
   });
 
   test("$schema completion with colon", async () => {
-    const documentUri = "file://path/to/workspace/subject2.schema.json";
+    const documentUri = "file:///path/to/workspace/subject2.schema.json";
     await openDocument(client, documentUri, `{
   "$schema":
 }`);
@@ -56,7 +56,7 @@ describe("Feature - $schema completion", () => {
   });
 
   test("$schema completion with colon and space", async () => {
-    const documentUri = "file://path/to/workspace/subject3.schema.json";
+    const documentUri = "file:///path/to/workspace/subject3.schema.json";
     await openDocument(client, documentUri, `{
   "$schema": 
 }`);
@@ -77,7 +77,7 @@ describe("Feature - $schema completion", () => {
   });
 
   test("$schema completion without colon", async () => {
-    const documentUri = "file://path/to/workspace/subject4.schema.json";
+    const documentUri = "file:///path/to/workspace/subject4.schema.json";
     await openDocument(client, documentUri, `{
   "$schema"
 }`);

--- a/language-server/src/features/workspace.test.js
+++ b/language-server/src/features/workspace.test.js
@@ -29,7 +29,7 @@ describe("Feature - workspace", () => {
     client = getTestClient([workspace, documentSettings, schemaRegistry]);
 
     workspaceFolder = await setupWorkspace({
-      "subject.schema.json": `{ "$schema": "https://json-schema.org/draft/2020-12/cshema" }`
+      "subject.schema.json": `{ "$schema": "https://json-schema.org/draft/2020-12/schema" }`
     });
 
     /**

--- a/language-server/src/schema-document.js
+++ b/language-server/src/schema-document.js
@@ -37,7 +37,7 @@ export const fromTextDocument = async (textDocument, contextDialectUri) => {
             instanceNode: $schema,
             message: "Unknown dialect"
           });
-        } else if (schemaResource.dialectUri) {
+        } else if (schemaResource.dialectUri !== undefined) {
           document.errors.push({
             keyword: "https://json-schema.org/keyword/schema",
             instanceNode: schemaResource,
@@ -72,7 +72,7 @@ export const fromTextDocument = async (textDocument, contextDialectUri) => {
   return document;
 };
 
-const buildSchemaResources = (document, node, uri = "", dialectUri = "", pointer = "", parent = undefined, anchors = {}) => {
+const buildSchemaResources = (document, node, uri = "", dialectUri = undefined, pointer = "", parent = undefined, anchors = {}) => {
   const schemaNode = SchemaNode.cons(uri, pointer, getNodeValue(node), node.type, [], parent, node.offset, node.length, dialectUri, anchors);
 
   switch (node.type) {

--- a/language-server/src/schema-node.js
+++ b/language-server/src/schema-node.js
@@ -16,7 +16,7 @@ export const cons = (uri, pointer, value, type, children, parent, offset, textLe
 
 export const get = (uri, node) => {
   const schemaId = toAbsoluteUri(resolveIri(uri, node?.baseUri));
-  const schemaResource = getSchemaResource(schemaId);
+  const schemaResource = node.baseUri === schemaId ? node : getSchemaResource(schemaId);
   if (!schemaResource) {
     return;
   }

--- a/language-server/src/test-utils.js
+++ b/language-server/src/test-utils.js
@@ -85,7 +85,7 @@ export const initializeServer = async (client, initParams = {}, settings = null)
   // TODO: This is a hack. Find a way to know when initialized is finished
   // Block for a while to allow InitializedNotification time to finish
   await new Promise((resolve) => {
-    setTimeout(resolve, 10);
+    setTimeout(resolve, 15);
   });
 
   return response.capabilities;


### PR DESCRIPTION
Tests for document-settings:
- default dialect and no dialect done.
- The unknown dialect error is never thrown in the desired case in extension host, that is a separate bug.
The tests pass locally at 15ms delay.
Maybe this is an issue with the hack
![image](https://github.com/hyperjump-io/json-schema-language-tools/assets/110971977/23c21fb7-f1b7-42cd-a296-d4639372b481)
