### PR TITLE
fix fallback workspace watching and workspace refresh

### DIFF
--- a/language-server/src/services/schemas-neovim.test.ts
+++ b/language-server/src/services/schemas-neovim.test.ts
@@ -49,7 +49,17 @@ describe("Feature - workspace (neovim)", () => {
     expect(schemaUris).to.eql([documentUriA, documentUriB]);
   });
 
-  test.todo("changing the workspace folders should validate the workspace", () => {
-    // DidChangeWorkspaceFoldersNotification
+  test("changing the workspace folders should validate the workspace", async () => {
+    const workspaceFolder = await client.createWorkspaceFolder();
+    const documentUriC = await client.writeDocument("./subjectC.schema.json", `{ "$schema": "https://json-schema.org/draft/2020-12/schema" }`, true, workspaceFolder);
+    const schemaUris: string[] = [];
+
+    client.onNotification(PublishDiagnosticsNotification.type, (params) => {
+      schemaUris.push(params.uri);
+    });
+
+    await client.changeWorkspaceFolders([workspaceFolder]);
+
+    expect(schemaUris).to.eql([documentUriA, documentUriB, documentUriC]);
   });
 });

--- a/language-server/src/services/schemas.js
+++ b/language-server/src/services/schemas.js
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -12,11 +12,10 @@ import { URI } from "vscode-uri";
 import { registerSchema, unregisterSchema } from "@hyperjump/json-schema/draft-2020-12";
 import { asyncCollectArray, asyncFilter, pipe, reduce } from "@hyperjump/pact";
 import * as JsonPointer from "@hyperjump/json-pointer";
-import { watch } from "chokidar";
 import ignore from "ignore";
 import * as SchemaDocument from "../model/schema-document.js";
 import * as SchemaNode from "../model/schema-node.js";
-import { createPromise, keywordNameFor, readDirRecursive, resolveIri, toAbsoluteUri, uriFragment } from "../util/util.js";
+import { keywordNameFor, readDirRecursive, resolveIri, toAbsoluteUri, uriFragment } from "../util/util.js";
 
 /**
  * @import {
@@ -29,12 +28,10 @@ import { createPromise, keywordNameFor, readDirRecursive, resolveIri, toAbsolute
  *   WorkspaceFolder
  * } from "vscode-languageserver"
  * @import { SchemaObject } from "@hyperjump/json-schema"
- * @import { FSWatcher } from "chokidar"
  * @import { Server } from "../services/server.js"
  * @import { SchemaDocument as SchemaDocumentType } from "../model/schema-document.js"
  * @import { SchemaNode as SchemaNodeType } from "../model/schema-node.js"
  * @import { Configuration } from "./configuration.js"
- * @import { MyPromise } from "../util/util.js"
  */
 
 
@@ -53,9 +50,9 @@ export class Schemas {
   /** @type Set<string> */
   #registeredSchemas;
 
-  /** @type FSWatcher | undefined */
-  #watcher;
   #watchEnabled;
+  /** @type Map<string, number> */
+  #watchedSchemaFiles;
 
   /** @type NotificationHandler<DidChangeWatchedFilesParams> */
   #didChangeWatchedFilesHandler;
@@ -115,6 +112,8 @@ export class Schemas {
         this.#server.workspace.onDidChangeWorkspaceFolders(({ added, removed }) => {
           this.addWorkspaceFolders(added);
           this.removeWorkspaceFolders(removed);
+          this.#clear();
+          this.#didChangeWatchedFilesHandler({ changes: [] });
         });
       }
     });
@@ -130,6 +129,7 @@ export class Schemas {
     this.#registeredSchemas = new Set();
 
     this.#watchEnabled = false;
+    this.#watchedSchemaFiles = new Map();
 
     this.#didChangeWatchedFilesHandler = () => {};
     this.#server.onDidChangeWatchedFiles((params) => {
@@ -153,58 +153,75 @@ export class Schemas {
   }
 
   async watch() {
-    /** @type Record<string, FileChangeType> */
-    let changes = {};
-
-    /** @type MyPromise<Record<string, FileChangeType>> */
-    let promise = createPromise();
-
-    this.#watcher = watch([...this.#workspaceFolders], { ignoreInitial: true })
-      .on("all", (event, /** @type string */ path) => {
-        if (event === "add") {
-          changes[path] = changes[path] === FileChangeType.Deleted ? FileChangeType.Changed : FileChangeType.Created;
-        } else if (event === "change") {
-          changes[path] = changes[path] === FileChangeType.Created ? FileChangeType.Created : FileChangeType.Changed;
-        } else if (event === "unlink") {
-          if (changes[path] === FileChangeType.Created) {
-            delete changes[path];
-          } else {
-            changes[path] = FileChangeType.Deleted;
-          }
-        } else {
-          return;
-        }
-
-        promise.resolve(changes);
-        promise = createPromise();
-      });
-
     this.#watchEnabled = true;
+    this.#watchedSchemaFiles = await this.#getWatchedSchemaFiles();
+
     while (this.#watchEnabled) {
-      const value = await promise.promise;
-      changes = {};
+      await new Promise((resolve) => setTimeout(resolve, 250));
 
+      const currentFiles = await this.#getWatchedSchemaFiles();
       /** @type FileEvent[] */
-      const fileEvents = [];
-      for (const path in value) {
-        const uri = URI.file(path).toString();
+      const changes = [];
 
-        fileEvents.push({
-          uri: uri,
-          type: value[path]
-        });
+      for (const [path, mtimeMs] of currentFiles) {
+        const previousMtimeMs = this.#watchedSchemaFiles.get(path);
+        if (previousMtimeMs === undefined) {
+          changes.push({ uri: URI.file(path).toString(), type: FileChangeType.Created });
+        } else if (previousMtimeMs !== mtimeMs) {
+          changes.push({ uri: URI.file(path).toString(), type: FileChangeType.Changed });
+        }
       }
 
-      this.#didChangeWatchedFilesHandler({ changes: fileEvents });
+      for (const path of this.#watchedSchemaFiles.keys()) {
+        if (!currentFiles.has(path)) {
+          changes.push({ uri: URI.file(path).toString(), type: FileChangeType.Deleted });
+        }
+      }
+
+      this.#watchedSchemaFiles = currentFiles;
+
+      if (changes.length > 0) {
+        this.#didChangeWatchedFilesHandler({ changes });
+      }
     }
   }
 
   /** @type () => Promise<void> */
-  async stop() {
+  stop() {
     this.#watchEnabled = false;
-    await this.#watcher?.close();
+    this.#watchedSchemaFiles.clear();
 
     this.#clear();
+    return Promise.resolve();
+  }
+
+  /** @type () => Promise<Map<string, number>> */
+  async #getWatchedSchemaFiles() {
+    /** @type Map<string, number> */
+    const watchedSchemaFiles = new Map();
+
+    for (const folderPath of this.#workspaceFolders) {
+      let gitignore;
+      try {
+        gitignore = await readFile(join(folderPath, ".gitignore"), "utf8");
+      } catch (_error) {
+        gitignore = "";
+      }
+
+      const filter = ignore()
+        .add(gitignore)
+        .add(".git/");
+
+      for await (const relativePath of readDirRecursive(folderPath, filter)) {
+        if (await this.#configuration.isSchema(relativePath)) {
+          const path = resolve(folderPath, relativePath);
+          const { mtimeMs } = await stat(path);
+          watchedSchemaFiles.set(path, mtimeMs);
+        }
+      }
+    }
+
+    return watchedSchemaFiles;
   }
 
   #clear() {
@@ -363,7 +380,6 @@ export class Schemas {
     for (const folder of folders) {
       const folderPath = fileURLToPath(folder.uri);
       this.#workspaceFolders.add(folderPath);
-      this.#watcher?.add(folderPath);
     }
   }
 
@@ -372,7 +388,6 @@ export class Schemas {
     for (const folder of folders) {
       const folderPath = fileURLToPath(folder.uri);
       this.#workspaceFolders.delete(folderPath);
-      this.#watcher?.unwatch(folderPath);
     }
   }
 

--- a/language-server/src/services/schemas.test.ts
+++ b/language-server/src/services/schemas.test.ts
@@ -57,7 +57,17 @@ describe("JSON Schema Language Server", () => {
     expect(schemaUris).to.eql([documentUriA, documentUriB]);
   });
 
-  test.todo("changing the workspace folders should validate the workspace", () => {
-    // DidChangeWorkspaceFoldersNotification
+  test("changing the workspace folders should validate the workspace", async () => {
+    const workspaceFolder = await client.createWorkspaceFolder();
+    const documentUriC = await client.writeDocument("./subjectC.schema.json", `{ "$schema": "https://json-schema.org/draft/2020-12/schema" }`, true, workspaceFolder);
+    const schemaUris: string[] = [];
+
+    client.onNotification(PublishDiagnosticsNotification.type, (params) => {
+      schemaUris.push(params.uri);
+    });
+
+    await client.changeWorkspaceFolders([workspaceFolder]);
+
+    expect(schemaUris).to.eql([documentUriA, documentUriB, documentUriC]);
   });
 });

--- a/language-server/src/test/test-client.ts
+++ b/language-server/src/test/test-client.ts
@@ -7,6 +7,7 @@ import {
   ConfigurationRequest,
   DidChangeConfigurationNotification,
   DidChangeWatchedFilesNotification,
+  DidChangeWorkspaceFoldersNotification,
   DidCloseTextDocumentNotification,
   DidOpenTextDocumentNotification,
   ExitNotification,
@@ -46,6 +47,7 @@ export class TestClient {
   private configurationChangeNotificationOptions: DidChangeConfigurationRegistrationOptions | null | undefined;
   private openDocuments: Set<string>;
   private workspaceFolder: Promise<string>;
+  private tempDirectories: Set<string>;
   private watchEnabled: boolean;
 
   onRequest: Connection["onRequest"];
@@ -59,8 +61,12 @@ export class TestClient {
     this.serverName = serverName;
     this.watchEnabled = false;
     this.openDocuments = new Set();
+    this.tempDirectories = new Set();
     this.workspaceFolder = mkdtemp(join(tmpdir(), "test-workspace-"))
-      .then((path) => URI.file(path).toString() + "/");
+      .then((path) => {
+        this.tempDirectories.add(path);
+        return URI.file(path).toString() + "/";
+      });
 
     const up = new TestStream();
     const down = new TestStream();
@@ -220,7 +226,7 @@ export class TestClient {
   async stop() {
     await this.client.sendRequest(ShutdownRequest.type);
     await this.client.sendNotification(ExitNotification.type);
-    await rm(fileURLToPath(await this.workspaceFolder), { recursive: true });
+    await Promise.all([...this.tempDirectories].map(async (path) => await rm(path, { recursive: true })));
     this.client.dispose();
   }
 
@@ -248,8 +254,9 @@ export class TestClient {
     await buildCompleted;
   }
 
-  async writeDocument(uri: string, text: string, isIgnored = false) {
-    const fullUri = resolveIri(uri, await this.workspaceFolder);
+  async writeDocument(uri: string, text: string, isIgnored = false, workspaceFolder?: string) {
+    workspaceFolder ??= await this.workspaceFolder;
+    const fullUri = resolveIri(uri, workspaceFolder);
     const exists = await access(fullUri).then(() => true).catch(() => false);
 
     await writeFile(fileURLToPath(fullUri), text, "utf-8");
@@ -272,8 +279,9 @@ export class TestClient {
     return fullUri;
   }
 
-  async deleteDocument(uri: string, isIgnored = false) {
-    const fullUri = resolveIri(uri, await this.workspaceFolder);
+  async deleteDocument(uri: string, isIgnored = false, workspaceFolder?: string) {
+    workspaceFolder ??= await this.workspaceFolder;
+    const fullUri = resolveIri(uri, workspaceFolder);
 
     await rm(fileURLToPath(fullUri));
 
@@ -320,6 +328,31 @@ export class TestClient {
         uri: uri
       }
     });
+  }
+
+  async createWorkspaceFolder(name = "workspace") {
+    const path = await mkdtemp(join(tmpdir(), `test-${name}-`));
+    this.tempDirectories.add(path);
+    return URI.file(path).toString() + "/";
+  }
+
+  async changeWorkspaceFolders(added: string[] = [], removed: string[] = []) {
+    const buildCompleted = this.buildCompleted();
+
+    await this.client.sendNotification(DidChangeWorkspaceFoldersNotification.type, {
+      event: {
+        added: added.map((uri, index) => ({
+          name: `workspace-${index + 1}`,
+          uri
+        })),
+        removed: removed.map((uri, index) => ({
+          name: `workspace-${index + 1}`,
+          uri
+        }))
+      }
+    });
+
+    await buildCompleted;
   }
 
   private buildCompleted() {


### PR DESCRIPTION

## summary

this pr fixes two workspace related issues in the language server

the first change replaces the fallback watcher that is used when the client does not support dynamic watched file registration

the second change makes the server revalidate the workspace when workspace folders are added or removed

i also replaced the two existing todo tests with real coverage in `schemas.test.ts` and `schemas-neovim.test.ts`

## problem

in the fallback watched files path the server was using a recursive `chokidar` watcher over the workspace

in my environment that could fail with `emfile: too many open files, watch`

workspace folder changes were also only updating the internal folder set and were not triggering a workspace refresh, so schemas in newly added folders were not validated immediately

## changes

replaced the fallback `chokidar` watcher in `schemas.js` with a polling based scan of schema files

tracked schema files by path and `mtimeMs` so the server can detect created changed and deleted files

cleared schema caches and triggered a workspace refresh when workspace folders change

added test client helpers in `test-client.ts` for creating additional workspace folders and sending `DidChangeWorkspaceFolders` notifications

replaced the two workspace folder todo tests in `schemas.test.ts` and `schemas-neovim.test.ts` with real tests

## why this approach

the polling based scan is only used in the fallback path when the client does not support dynamic watched file registration

this avoids exhausting os watch handles while still feeding the existing workspace validation flow with equivalent file change events

for workspace folder changes i reused the existing workspace refresh path instead of adding a separate validation path

## testing

ran `npm run lint` in `language-server`

ran `npm run type-check` in `language-server`

ran `npm test` in `language-server`

all passed

i did not open an issue first because this looked like a focused fix for an existing failing fallback path and two existing workspace folder test todos, but i am happy to split or revise the change if you would prefer it discussed first