### PR TITLE
feat(validation): implement incremental validation (#17)

### DIFF
--- a/language-server/src/build-server.js
+++ b/language-server/src/build-server.js
@@ -2,6 +2,7 @@
 import { Server } from "./services/server.js";
 import { Configuration } from "./services/configuration.js";
 import { Schemas } from "./services/schemas.js";
+import { Dependencies } from "./services/dependencies.js";
 
 // Features
 import { CompletionFeature } from "./features/completion/completion.js";
@@ -61,7 +62,8 @@ export const buildServer = (connection) => {
 
   // TODO: It's awkward that validateSchema needs a variable
   const validateSchema = new ValidateSchemaFeature(server, schemas, diagnostics);
-  new ValidateWorkspaceFeature(server, schemas, configuration, validateSchema);
+  const dependencies = new Dependencies(server, schemas);
+  new ValidateWorkspaceFeature(server, schemas, configuration, validateSchema, dependencies);
 
   new CompletionFeature(server, schemas, [
     new SchemaCompletionProvider(),

--- a/language-server/src/features/validate-workspace.js
+++ b/language-server/src/features/validate-workspace.js
@@ -7,6 +7,7 @@ import { hasDialect } from "@hyperjump/json-schema/experimental";
  * @import { Schemas } from "../services/schemas.js";
  * @import { Configuration } from "../services/configuration.js";
  * @import { ValidateSchemaFeature } from "./validate-schema.js";
+ * @import { Dependencies } from "../services/dependencies.js";
  */
 
 
@@ -15,18 +16,21 @@ export class ValidateWorkspaceFeature {
   #schemas;
   #configuration;
   #validateSchema;
+  #dependencies;
 
   /**
    * @param {Server} server
    * @param {Schemas} schemas
    * @param {Configuration} configuration
    * @param {ValidateSchemaFeature} validateSchema
+   * @param {Dependencies} dependencies
    */
-  constructor(server, schemas, configuration, validateSchema) {
+  constructor(server, schemas, configuration, validateSchema, dependencies) {
     this.#server = server;
     this.#schemas = schemas;
     this.#configuration = configuration;
     this.#validateSchema = validateSchema;
+    this.#dependencies = dependencies;
 
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     this.#schemas.onDidChangeWatchedFiles(async (params) => {
@@ -75,6 +79,9 @@ export class ValidateWorkspaceFeature {
     for await (const schemaDocument of this.#schemas.all()) {
       await this.#validateSchema.validateSchema(schemaDocument);
     }
+
+    await this.#dependencies.build();
+    this.#dependencies.print();
 
     await this.#server.sendRequest(SemanticTokensRefreshRequest.type);
 

--- a/language-server/src/features/validate-workspace.js
+++ b/language-server/src/features/validate-workspace.js
@@ -9,7 +9,6 @@ import { hasDialect } from "@hyperjump/json-schema/experimental";
  * @import { ValidateSchemaFeature } from "./validate-schema.js";
  * @import { Dependencies } from "../services/dependencies.js";
  * @import { FileEvent } from "vscode-languageserver"
- * @import { SchemaDocument } from "../model/schema-document.js"
  */
 
 
@@ -77,57 +76,15 @@ export class ValidateWorkspaceFeature {
       await this.#schemas.getOpen(schemaUri, true);
     }
 
-    // NOTE: When the workspace is first loaded, we need to validate all schemas
-    const shouldValidateWorkspace = changes.length === 0;
-    // NOTE: We find the affected schemas before rebuilding the dependencies.
-    // e.g. If A depends on B, and B is deleted, and we build the dependencies first,
-    // we would have already removed B from the workspace, so the graph would have no dependents.
-    const affectedSchemas = shouldValidateWorkspace ? this.#schemas.all() : this.#findAffectedSchemas(changes);
+    const affectedSchemas = await this.#dependencies.sync(changes);
 
     // Re/validate affected schemas
     for await (const schemaDocument of affectedSchemas) {
       await this.#validateSchema.validateSchema(schemaDocument);
     }
 
-    await this.#dependencies.build();
-    this.#dependencies.print();
-
     await this.#server.sendRequest(SemanticTokensRefreshRequest.type);
 
     reporter.done();
-  }
-
-  /**
-   * @param {FileEvent[]} changes
-   * @returns {AsyncGenerator<SchemaDocument>}
-   */
-  async* #findAffectedSchemas(changes) {
-    const affectedUris = this.#findAffectedUris(changes);
-    for (const uri of affectedUris) {
-      const schemaDocument = await this.#schemas.get(uri);
-      if (schemaDocument) {
-        yield schemaDocument;
-      }
-    }
-  }
-
-  /**
-   * @param {FileEvent[]} changes
-   * @returns {Set<string>}
-   */
-  #findAffectedUris(changes) {
-    /** @type {Set<string>} */
-    const affectedUris = new Set();
-    for (const change of changes) {
-      if (change.type !== FileChangeType.Deleted) {
-        // NOTE: When a file is deleted, we don't need to revalidate it, as it will be removed from the workspace
-        affectedUris.add(change.uri);
-      }
-      const dependents = this.#dependencies.findDependents(change.uri);
-      for (const dependent of dependents) {
-        affectedUris.add(dependent);
-      }
-    }
-    return affectedUris;
   }
 }

--- a/language-server/src/features/validate-workspace.js
+++ b/language-server/src/features/validate-workspace.js
@@ -8,6 +8,8 @@ import { hasDialect } from "@hyperjump/json-schema/experimental";
  * @import { Configuration } from "../services/configuration.js";
  * @import { ValidateSchemaFeature } from "./validate-schema.js";
  * @import { Dependencies } from "../services/dependencies.js";
+ * @import { FileEvent } from "vscode-languageserver"
+ * @import { SchemaDocument } from "../model/schema-document.js"
  */
 
 
@@ -75,8 +77,15 @@ export class ValidateWorkspaceFeature {
       await this.#schemas.getOpen(schemaUri, true);
     }
 
-    // Re/validate all schemas
-    for await (const schemaDocument of this.#schemas.all()) {
+    // NOTE: When the workspace is first loaded, we need to validate all schemas
+    const shouldValidateWorkspace = changes.length === 0;
+    // NOTE: We find the affected schemas before rebuilding the dependencies.
+    // e.g. If A depends on B, and B is deleted, and we build the dependencies first,
+    // we would have already removed B from the workspace, so the graph would have no dependents.
+    const affectedSchemas = shouldValidateWorkspace ? this.#schemas.all() : this.#findAffectedSchemas(changes);
+
+    // Re/validate affected schemas
+    for await (const schemaDocument of affectedSchemas) {
       await this.#validateSchema.validateSchema(schemaDocument);
     }
 
@@ -86,5 +95,39 @@ export class ValidateWorkspaceFeature {
     await this.#server.sendRequest(SemanticTokensRefreshRequest.type);
 
     reporter.done();
+  }
+
+  /**
+   * @param {FileEvent[]} changes
+   * @returns {AsyncGenerator<SchemaDocument>}
+   */
+  async* #findAffectedSchemas(changes) {
+    const affectedUris = this.#findAffectedUris(changes);
+    for (const uri of affectedUris) {
+      const schemaDocument = await this.#schemas.get(uri);
+      if (schemaDocument) {
+        yield schemaDocument;
+      }
+    }
+  }
+
+  /**
+   * @param {FileEvent[]} changes
+   * @returns {Set<string>}
+   */
+  #findAffectedUris(changes) {
+    /** @type {Set<string>} */
+    const affectedUris = new Set();
+    for (const change of changes) {
+      if (change.type !== FileChangeType.Deleted) {
+        // NOTE: When a file is deleted, we don't need to revalidate it, as it will be removed from the workspace
+        affectedUris.add(change.uri);
+      }
+      const dependents = this.#dependencies.findDependents(change.uri);
+      for (const dependent of dependents) {
+        affectedUris.add(dependent);
+      }
+    }
+    return affectedUris;
   }
 }

--- a/language-server/src/features/validate-workspace.test.ts
+++ b/language-server/src/features/validate-workspace.test.ts
@@ -1,0 +1,297 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { PublishDiagnosticsNotification } from "vscode-languageserver";
+import { TestClient } from "../test/test-client.ts";
+
+const employeeSchema = `{
+  "$id": "https://test.com/schemas/employee",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "role": { "type": "string" }
+  }
+}`;
+
+const policySchema = `{
+  "$id": "https://test.com/schemas/policy",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+    "https://json-schema.org/draft/2020-12/vocab/core": true,
+    "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+    "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+    "https://json-schema.org/draft/2020-12/vocab/validation": true,
+    "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+    "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+    "https://json-schema.org/draft/2020-12/vocab/content": true
+  },
+  "allOf": [
+    { "$ref": "https://json-schema.org/draft/2020-12/schema" }
+  ],
+  "properties": {
+    "security_level": { "type": "string", "enum": ["low", "high"] }
+  },
+  "required": ["security_level"]
+}`;
+
+const projectSchema = `{
+  "$id": "https://test.com/schemas/project",
+  "$schema": "https://test.com/schemas/policy",
+  "security_level": "high",
+  "type": "object",
+  "properties": {
+    "project_name": { "type": "string" },
+    "lead": { "$ref": "https://test.com/schemas/employee" }
+  }
+}`;
+
+const reportSchema = `{
+  "$id": "https://test.com/schemas/report",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "main_project": { "$ref": "https://test.com/schemas/project" }
+  }
+}`;
+
+describe("Incremental Workspace Validation", () => {
+  let client: TestClient;
+  let employeeUri: string;
+  let policyUri: string;
+  let projectUri: string;
+  let reportUri: string;
+  const schemaUris: string[] = [];
+
+  beforeAll(async () => {
+    client = new TestClient();
+    await client.start();
+
+    client.onNotification(PublishDiagnosticsNotification.type, (params) => {
+      schemaUris.push(params.uri);
+    });
+
+    employeeUri = await client.writeDocument("./employee.schema.json", employeeSchema);
+    policyUri = await client.writeDocument("./policy.schema.json", policySchema);
+    projectUri = await client.writeDocument("./project.schema.json", projectSchema);
+    reportUri = await client.writeDocument("./report.schema.json", reportSchema);
+  });
+
+  beforeEach(() => {
+    schemaUris.length = 0;
+  });
+
+  afterAll(async () => {
+    await client.stop();
+  });
+
+  test("editing a schema with no dependents should revalidate only itself", async () => {
+    await client.writeDocument("./report.schema.json", reportSchema);
+
+    expect(schemaUris).to.include(reportUri);
+    expect(schemaUris.length).to.equal(1);
+  });
+
+  test("editing a schema with direct dependents should only revalidate itself and its direct dependents", async () => {
+    await client.writeDocument("./project.schema.json", projectSchema);
+
+    expect(schemaUris).to.include(projectUri);
+    expect(schemaUris).to.include(reportUri);
+    expect(schemaUris.length).to.equal(2);
+  });
+
+  test("editing a schema with indirect dependents should only revalidate itself and the whole dependent chain", async () => {
+    await client.writeDocument("./employee.schema.json", employeeSchema);
+
+    expect(schemaUris).to.include(employeeUri);
+    expect(schemaUris).to.include(projectUri);
+    expect(schemaUris).to.include(reportUri);
+    expect(schemaUris).to.not.include(policyUri);
+    expect(schemaUris.length).to.equal(3);
+  });
+
+  test("editing a meta schema should revalidate itself and schemas using it as a dialect", async () => {
+    const metaSchema = `{ 
+      "$id": "https://test.com/schemas/meta-test",
+      "$schema": "https://json-schema.org/draft/2020-12/schema"
+    }`;
+    const dependentSchema = `{ 
+      "$id": "https://test.com/schemas/meta-dependent",
+      "$schema": "https://test.com/schemas/meta-test" 
+    }`;
+    const metaUri = await client.writeDocument("./meta-test.schema.json", metaSchema);
+    const dependentUri = await client.writeDocument("./meta-dependent.schema.json", dependentSchema);
+
+    schemaUris.length = 0;
+
+    await client.writeDocument("./meta-test.schema.json", metaSchema);
+
+    expect(schemaUris).to.include(metaUri);
+    expect(schemaUris).to.include(dependentUri);
+    expect(schemaUris.length).to.equal(2);
+  });
+
+  test("editing a schema with circular dependencies should not cause infinite loops", async () => {
+    const circularASchema = `{
+      "$id": "https://test.com/schemas/circularA",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$ref": "https://test.com/schemas/circularB"
+    }`;
+    const circularBSchema = `{
+      "$id": "https://test.com/schemas/circularB",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$ref": "https://test.com/schemas/circularA"
+    }`;
+    const circularAUri = await client.writeDocument("./circularA.schema.json", circularASchema);
+    const circularBUri = await client.writeDocument("./circularB.schema.json", circularBSchema);
+
+    schemaUris.length = 0;
+
+    await client.writeDocument("./circularA.schema.json", circularASchema);
+
+    expect(schemaUris).to.include(circularAUri);
+    expect(schemaUris).to.include(circularBUri);
+    expect(schemaUris.length).to.equal(2);
+
+    schemaUris.length = 0;
+
+    await client.writeDocument("./circularB.schema.json", circularBSchema);
+
+    expect(schemaUris).to.include(circularAUri);
+    expect(schemaUris).to.include(circularBUri);
+    expect(schemaUris.length).to.equal(2);
+  });
+
+  test("deleting a schema should revalidate the dependent chain and clear itself", async () => {
+    await client.deleteDocument(employeeUri);
+
+    expect(schemaUris).to.include(employeeUri);
+    expect(schemaUris).to.include(projectUri);
+    expect(schemaUris).to.include(reportUri);
+    expect(schemaUris.length).to.equal(3);
+  });
+
+  test("removing a reference should not trigger revalidation of the dependent chain", async () => {
+    const projectSchemaNoRef = `{
+      "$id": "https://test.com/schemas/project",
+      "$schema": "https://test.com/schemas/policy",
+      "security_level": "high",
+      "properties": { "project_name": { "type": "string" } }
+    }`;
+    await client.writeDocument("./project.schema.json", projectSchemaNoRef);
+
+    schemaUris.length = 0;
+
+    await client.writeDocument("./employee.schema.json", employeeSchema);
+
+    expect(schemaUris).to.include(employeeUri);
+    expect(schemaUris.length).to.equal(1);
+  });
+
+  test("adding a reference should trigger revalidation of the dependent chain", async () => {
+    await client.writeDocument("./project.schema.json", projectSchema);
+
+    schemaUris.length = 0;
+
+    await client.writeDocument("./employee.schema.json", employeeSchema);
+
+    expect(schemaUris).to.include(employeeUri);
+    expect(schemaUris).to.include(projectUri);
+    expect(schemaUris).to.include(reportUri);
+    expect(schemaUris.length).to.equal(3);
+  });
+
+  test.todo("resolution of missing schemas should trigger revalidation when the schema becomes available", async () => {
+    const aSchema = `{ 
+      "$id": "https://test.com/schemas/a",
+      "$schema": "https://json-schema.org/draft/2020-12/schema"
+    }`;
+    const bSchema = `{ 
+      "$id": "https://test.com/schemas/b",
+      "$schema": "https://test.com/schemas/a" 
+    }`;
+    const bUri = await client.writeDocument("./b.schema.json", bSchema);
+
+    schemaUris.length = 0;
+
+    const aUri = await client.writeDocument("./a.schema.json", aSchema);
+
+    expect(schemaUris).to.include(bUri);
+    expect(schemaUris).to.include(aUri);
+    expect(schemaUris.length).to.equal(2);
+  });
+
+  test("changing $id should trigger revalidation of its dependents", async () => {
+    const aSchema = `{ 
+      "$id": "https://test.com/schemas/a-v1",
+      "$schema": "https://json-schema.org/draft/2020-12/schema" 
+    }`;
+    const bSchema = `{ 
+      "$id": "https://test.com/schemas/b",
+      "$schema": "https://test.com/schemas/a-v1" 
+    }`;
+    const aUri = await client.writeDocument("./a.schema.json", aSchema);
+    const bUri = await client.writeDocument("./b.schema.json", bSchema);
+
+    schemaUris.length = 0;
+
+    await client.writeDocument("./a.schema.json", aSchema.replace("/a-v1", "/a-v2"));
+
+    expect(schemaUris).to.include(aUri);
+    expect(schemaUris).to.include(bUri);
+    expect(schemaUris.length).to.equal(2);
+  });
+
+  test("editing a schema with fragment references should revalidate its dependents", async () => {
+    const aSchema = `{ 
+      "$id": "https://test.com/schemas/a",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": { "foo": { "type": "string" } }
+    }`;
+    const bSchema = `{ 
+      "$id": "https://test.com/schemas/b",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$ref": "https://test.com/schemas/a#/$defs/foo" 
+    }`;
+    const aUri = await client.writeDocument("./a.schema.json", aSchema);
+    const bUri = await client.writeDocument("./b.schema.json", bSchema);
+
+    schemaUris.length = 0;
+
+    await client.writeDocument("./a.schema.json", aSchema);
+
+    expect(schemaUris).to.include(aUri);
+    expect(schemaUris).to.include(bUri);
+    expect(schemaUris.length).to.equal(2);
+  });
+
+  test.todo("multiple schemas with the same $id should revalidate their dependents when either is edited", async () => {
+    const aSchema = `{ 
+      "$id": "https://test.com/schemas/shared",
+      "$schema": "https://json-schema.org/draft/2020-12/schema"
+    }`;
+    const bSchema = `{ 
+      "$id": "https://test.com/schemas/b",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$ref": "https://test.com/schemas/shared" 
+    }`;
+    const cSchema = `{ 
+      "$id": "https://test.com/schemas/shared",
+      "$schema": "https://json-schema.org/draft/2020-12/schema"
+    }`;
+    const aUri = await client.writeDocument("./a.schema.json", aSchema);
+    const bUri = await client.writeDocument("./b.schema.json", bSchema);
+    const cUri = await client.writeDocument("./c.schema.json", cSchema);
+
+    schemaUris.length = 0;
+
+    await client.writeDocument("./a.schema.json", aSchema);
+    expect(schemaUris).to.include(aUri);
+    expect(schemaUris).to.include(bUri);
+    expect(schemaUris.length).toBe(2);
+
+    schemaUris.length = 0;
+
+    await client.writeDocument("./c.schema.json", cSchema);
+    expect(schemaUris).to.include(cUri);
+    expect(schemaUris).to.include(bUri);
+    expect(schemaUris.length).to.equal(2);
+  });
+});

--- a/language-server/src/features/validate-workspace.test.ts
+++ b/language-server/src/features/validate-workspace.test.ts
@@ -198,7 +198,7 @@ describe("Incremental Workspace Validation", () => {
     expect(schemaUris.length).to.equal(3);
   });
 
-  test.todo("resolution of missing schemas should trigger revalidation when the schema becomes available", async () => {
+  test("resolution of missing schemas should trigger revalidation when the schema becomes available", async () => {
     const aSchema = `{ 
       "$id": "https://test.com/schemas/a",
       "$schema": "https://json-schema.org/draft/2020-12/schema"
@@ -262,7 +262,7 @@ describe("Incremental Workspace Validation", () => {
     expect(schemaUris.length).to.equal(2);
   });
 
-  test.todo("multiple schemas with the same $id should revalidate their dependents when either is edited", async () => {
+  test("multiple schemas with the same $id should revalidate their dependents when either is edited", async () => {
     const aSchema = `{ 
       "$id": "https://test.com/schemas/shared",
       "$schema": "https://json-schema.org/draft/2020-12/schema"

--- a/language-server/src/services/dependencies.js
+++ b/language-server/src/services/dependencies.js
@@ -1,23 +1,38 @@
 import { resolveIri, toAbsoluteUri } from "../util/util.js";
 import { value } from "../model/schema-node.js";
+import { FileChangeType } from "vscode-languageserver";
 
 /**
  * @import { Server } from "./server.js";
  * @import { Schemas } from "./schemas.js";
+ * @import { FileEvent } from "vscode-languageserver";
+ * @import { SchemaDocument } from "../model/schema-document.js"
+ */
+
+/**
+ * @typedef {string} FileSystemUri
+ * A URI that can be resolved to a file path on the filesystem
+ */
+
+/**
+ * @typedef {string} SchemaUri
+ * A URI that identifies a schema it could be a file system URI or an id
  */
 
 /**
  * @typedef {Object} DependencyRecord
- * @property {string} uri
- * @property {Set<string>} dependencies
- * @property {Set<string>} dependents
+ * @property {FileSystemUri} uri
+ * @property {Set<SchemaUri>} dependencies
+ * @property {Set<SchemaUri>} definitions
  */
 
 export class Dependencies {
   #server;
   #schemas;
-  /** @type {Map<string, DependencyRecord>} */
+  /** @type {Map<FileSystemUri, DependencyRecord>} */
   #records;
+  /** @type {Map<SchemaUri, Set<FileSystemUri>>} */
+  #dependents;
 
   /**
    * @param {Server} server
@@ -27,50 +42,80 @@ export class Dependencies {
     this.#server = server;
     this.#schemas = schemas;
     this.#records = new Map();
+    this.#dependents = new Map();
   }
 
   async build() {
     this.#server.console.log("Extracting Dependencies");
     this.#records.clear();
+    this.#dependents.clear();
 
     for await (const schemaDocument of this.#schemas.all()) {
       const uri = schemaDocument.textDocument.uri;
       const dependent = this.#getOrCreateRecord(uri);
       for (const schemaResource of schemaDocument.schemaResources) {
+        dependent.definitions.add(schemaResource.baseUri);
         if (schemaResource.dialectUri) {
-          this.#addDependencyIfLocal(dependent, schemaResource.dialectUri);
+          this.#addDependency(dependent, schemaResource.dialectUri);
         }
         for (const reference of this.#schemas.references(schemaResource)) {
           /** @type {string} */
           const referenceValue = value(reference);
           const referencedUri = toAbsoluteUri(resolveIri(referenceValue, schemaResource.baseUri));
-          this.#addDependencyIfLocal(dependent, referencedUri);
+          this.#addDependency(dependent, referencedUri);
         }
       }
     }
   }
 
   /**
-   * @param {string} uri
-   * @returns {DependencyRecord | undefined}
+   * @param {FileEvent[]} changes
+   * @returns {Promise<AsyncIterable<SchemaDocument> | Iterable<SchemaDocument>>}
    */
-  get(uri) {
-    return this.#records.get(uri);
+  async sync(changes) {
+    const shouldValidateAllSchemas = !changes.length;
+    if (shouldValidateAllSchemas) {
+      await this.build();
+      return this.#schemas.all();
+    }
+    /** @type {Set<FileSystemUri>} */
+    const affectedUris = new Set();
+    const affectedSchemas = [];
+    // We are calling findAffectedUris before updating the dependencies
+    // because if a file is deleted, it will be removed from the dependencies
+    // and we won't be able to find its dependents after the update.
+    // This also happens if a file defined an id that now is deleted.
+    this.#findAffectedUris(changes, affectedUris);
+    await this.build();
+    // We are also calling findAffectedUris after updating the dependencies
+    // because if a file is added, we need to find its dependents.
+    // This also happens if a file now defines an id that it didn't before.
+    this.#findAffectedUris(changes, affectedUris);
+    for (const uri of affectedUris) {
+      const schemaDocument = await this.#schemas.get(uri);
+      if (schemaDocument) {
+        affectedSchemas.push(schemaDocument);
+      }
+    }
+    return affectedSchemas;
   }
 
   /**
-   * @param {string} uri
-   * @param {Set<string>} dependents
-   * @returns {Set<string>}
+   * @param {FileSystemUri} uri
+   * @param {Set<FileSystemUri>} dependents
+   * @returns {Set<FileSystemUri>}
    */
   findDependents(uri, dependents = new Set()) {
-    const dependency = this.get(uri);
-    if (!dependency) return dependents;
+    const record = this.#records.get(uri);
+    const handles = record?.definitions ?? new Set();
 
-    for (const dependent of dependency.dependents) {
-      if (dependents.has(dependent)) continue;
-      dependents.add(dependent);
-      this.findDependents(dependent, dependents);
+    for (const handle of handles) {
+      const directDependents = this.#dependents.get(handle) ?? new Set();
+      for (const directDependent of directDependents) {
+        if (dependents.has(directDependent)) continue;
+        dependents.add(directDependent);
+        this.findDependents(directDependent, dependents);
+      }
     }
 
     return dependents;
@@ -78,24 +123,20 @@ export class Dependencies {
 
   /**
    * @param {DependencyRecord} dependent
-   * @param {string} dependencyUri
+   * @param {SchemaUri} dependencyUri
    */
-  #addDependencyIfLocal(dependent, dependencyUri) {
-    // NOTE: Tracks only local filesystem schemas.
-    // If a schema URI (e.g https://...) does not have a corresponding document,
-    // we can't resolve its path, we can't watch it for changes, so tracking it adds no value.
-    const dependencyDocument = this.#schemas.getBySchemaUri(dependencyUri);
-    if (!dependencyDocument) {
-      return;
+  #addDependency(dependent, dependencyUri) {
+    dependent.dependencies.add(dependencyUri);
+    let dependents = this.#dependents.get(dependencyUri);
+    if (!dependents) {
+      dependents = new Set();
+      this.#dependents.set(dependencyUri, dependents);
     }
-    const localDependencyUri = dependencyDocument.textDocument.uri;
-    const dependency = this.#getOrCreateRecord(localDependencyUri);
-    dependent.dependencies.add(localDependencyUri);
-    dependency.dependents.add(dependent.uri);
+    dependents.add(dependent.uri);
   }
 
   /**
-   * @param {string} uri
+   * @param {FileSystemUri} uri
    * @returns {DependencyRecord}
    */
   #getOrCreateRecord(uri) {
@@ -105,12 +146,31 @@ export class Dependencies {
       dependencyRecord = {
         uri,
         dependencies: new Set(),
-        dependents: new Set()
+        definitions: new Set([uri])
       };
       this.#records.set(uri, dependencyRecord);
     }
 
     return dependencyRecord;
+  }
+
+  /**
+   * @param {FileEvent[]} changes
+   * @param {Set<FileSystemUri>} affectedUris
+   * @returns {Set<string>}
+   */
+  #findAffectedUris(changes, affectedUris = new Set()) {
+    for (const change of changes) {
+      if (change.type !== FileChangeType.Deleted) {
+        // NOTE: When a file is deleted, we don't need to revalidate it, as it will be removed from the workspace
+        affectedUris.add(change.uri);
+      }
+      const dependents = this.findDependents(change.uri);
+      for (const dependent of dependents) {
+        affectedUris.add(dependent);
+      }
+    }
+    return affectedUris;
   }
 
   print() {

--- a/language-server/src/services/dependencies.js
+++ b/language-server/src/services/dependencies.js
@@ -50,47 +50,60 @@ export class Dependencies {
    * @returns {Promise<AsyncIterable<SchemaDocument> | Iterable<SchemaDocument>>}
    */
   async sync(changes) {
-    const shouldValidateAllSchemas = !changes.length;
-    if (shouldValidateAllSchemas) {
-      await this.addAllSchemas();
+    const isInitial = !changes.length;
+    if (isInitial) {
+      await this.#init();
       return this.#schemas.all();
     }
     /** @type {Set<FileSystemUri>} */
     const affectedUris = new Set();
-    const affectedSchemas = [];
     // We are calling findAffectedUris before updating the dependencies
     // because if a file is deleted, it will be removed from the dependencies
     // and we won't be able to find its dependents after the update.
     // This also happens if a file defined an id that now is deleted.
     this.#findAffectedUris(changes, affectedUris);
-    await this.updateSchemas(changes);
+    await this.#applyChanges(changes);
     // We are also calling findAffectedUris after updating the dependencies
     // because if a file is added, we need to find its dependents.
     // This also happens if a file now defines an id that it didn't before.
     this.#findAffectedUris(changes, affectedUris);
-    for (const uri of affectedUris) {
-      const schemaDocument = await this.#schemas.get(uri);
-      if (schemaDocument) {
-        affectedSchemas.push(schemaDocument);
-      }
-    }
-    return affectedSchemas;
+    return this.#resolveSchemas(affectedUris);
   }
 
-  async addAllSchemas() {
+  async #init() {
     this.#records.clear();
     this.#dependents.clear();
     for await (const schemaDocument of this.#schemas.all()) {
-      this.addSchema(schemaDocument);
+      this.#addSchema(schemaDocument);
+    }
+  }
+
+  /**
+   * @param {FileEvent[]} changes
+   */
+  async #applyChanges(changes) {
+    for (const change of changes) {
+      switch (change.type) {
+        case FileChangeType.Created:
+        case FileChangeType.Changed: {
+          const document = await this.#schemas.get(change.uri);
+          this.#addSchema(document);
+          break;
+        }
+        case FileChangeType.Deleted: {
+          this.#removeSchema(change.uri);
+          break;
+        }
+      }
     }
   }
 
   /**
    * @param {SchemaDocument} schemaDocument
    */
-  addSchema(schemaDocument) {
+  #addSchema(schemaDocument) {
     const uri = schemaDocument.textDocument.uri;
-    this.removeSchema(uri);
+    this.#removeSchema(uri);
     const dependent = this.#createRecord(uri);
     for (const schemaResource of schemaDocument.schemaResources) {
       dependent.definitions.add(schemaResource.baseUri);
@@ -109,7 +122,7 @@ export class Dependencies {
   /**
    * @param {FileSystemUri} uri
    */
-  removeSchema(uri) {
+  #removeSchema(uri) {
     const record = this.#records.get(uri);
     if (!record) {
       return;
@@ -122,31 +135,11 @@ export class Dependencies {
   }
 
   /**
-   * @param {FileEvent[]} changes
-   */
-  async updateSchemas(changes) {
-    for (const change of changes) {
-      switch (change.type) {
-        case FileChangeType.Created:
-        case FileChangeType.Changed: {
-          const document = await this.#schemas.get(change.uri);
-          this.addSchema(document);
-          break;
-        }
-        case FileChangeType.Deleted: {
-          this.removeSchema(change.uri);
-          break;
-        }
-      }
-    }
-  }
-
-  /**
    * @param {FileSystemUri} uri
    * @param {Set<FileSystemUri>} dependents
    * @returns {Set<FileSystemUri>}
    */
-  findDependents(uri, dependents = new Set()) {
+  #findDependents(uri, dependents = new Set()) {
     const record = this.#records.get(uri);
     const handles = record?.definitions ?? new Set();
 
@@ -155,7 +148,7 @@ export class Dependencies {
       for (const directDependent of directDependents) {
         if (dependents.has(directDependent)) continue;
         dependents.add(directDependent);
-        this.findDependents(directDependent, dependents);
+        this.#findDependents(directDependent, dependents);
       }
     }
 
@@ -198,10 +191,10 @@ export class Dependencies {
   #findAffectedUris(changes, affectedUris = new Set()) {
     for (const change of changes) {
       if (change.type !== FileChangeType.Deleted) {
-        // NOTE: When a file is deleted, we don't need to revalidate it, as it will be removed from the workspace
+        // When a file is deleted, we don't need to revalidate it, as it will be removed from the workspace
         affectedUris.add(change.uri);
       }
-      const dependents = this.findDependents(change.uri);
+      const dependents = this.#findDependents(change.uri);
       for (const dependent of dependents) {
         affectedUris.add(dependent);
       }
@@ -209,12 +202,16 @@ export class Dependencies {
     return affectedUris;
   }
 
-  print() {
-    for (const [key, value] of this.#records) {
-      const dependencies = value.dependencies;
-      for (const dependency of dependencies) {
-        this.#server.console.log(`${key} -> ${dependency}`);
-      }
-    }
+  /**
+   * @param {Set<FileSystemUri>} uris
+   * @returns {Promise<SchemaDocument[]>}
+   */
+  async #resolveSchemas(uris) {
+    const documents = await Promise.all(
+      Array.from(uris).map((uri) =>
+        this.#schemas.get(uri)
+      )
+    );
+    return documents.filter(Boolean);
   }
 }

--- a/language-server/src/services/dependencies.js
+++ b/language-server/src/services/dependencies.js
@@ -51,6 +51,32 @@ export class Dependencies {
   }
 
   /**
+   * @param {string} uri
+   * @returns {DependencyRecord | undefined}
+   */
+  get(uri) {
+    return this.#records.get(uri);
+  }
+
+  /**
+   * @param {string} uri
+   * @param {Set<string>} dependents
+   * @returns {Set<string>}
+   */
+  findDependents(uri, dependents = new Set()) {
+    const dependency = this.get(uri);
+    if (!dependency) return dependents;
+
+    for (const dependent of dependency.dependents) {
+      if (dependents.has(dependent)) continue;
+      dependents.add(dependent);
+      this.findDependents(dependent, dependents);
+    }
+
+    return dependents;
+  }
+
+  /**
    * @param {DependencyRecord} dependent
    * @param {string} dependencyUri
    */

--- a/language-server/src/services/dependencies.js
+++ b/language-server/src/services/dependencies.js
@@ -45,29 +45,6 @@ export class Dependencies {
     this.#dependents = new Map();
   }
 
-  async build() {
-    this.#server.console.log("Extracting Dependencies");
-    this.#records.clear();
-    this.#dependents.clear();
-
-    for await (const schemaDocument of this.#schemas.all()) {
-      const uri = schemaDocument.textDocument.uri;
-      const dependent = this.#getOrCreateRecord(uri);
-      for (const schemaResource of schemaDocument.schemaResources) {
-        dependent.definitions.add(schemaResource.baseUri);
-        if (schemaResource.dialectUri) {
-          this.#addDependency(dependent, schemaResource.dialectUri);
-        }
-        for (const reference of this.#schemas.references(schemaResource)) {
-          /** @type {string} */
-          const referenceValue = value(reference);
-          const referencedUri = toAbsoluteUri(resolveIri(referenceValue, schemaResource.baseUri));
-          this.#addDependency(dependent, referencedUri);
-        }
-      }
-    }
-  }
-
   /**
    * @param {FileEvent[]} changes
    * @returns {Promise<AsyncIterable<SchemaDocument> | Iterable<SchemaDocument>>}
@@ -75,7 +52,7 @@ export class Dependencies {
   async sync(changes) {
     const shouldValidateAllSchemas = !changes.length;
     if (shouldValidateAllSchemas) {
-      await this.build();
+      await this.addAllSchemas();
       return this.#schemas.all();
     }
     /** @type {Set<FileSystemUri>} */
@@ -86,7 +63,7 @@ export class Dependencies {
     // and we won't be able to find its dependents after the update.
     // This also happens if a file defined an id that now is deleted.
     this.#findAffectedUris(changes, affectedUris);
-    await this.build();
+    await this.updateSchemas(changes);
     // We are also calling findAffectedUris after updating the dependencies
     // because if a file is added, we need to find its dependents.
     // This also happens if a file now defines an id that it didn't before.
@@ -98,6 +75,70 @@ export class Dependencies {
       }
     }
     return affectedSchemas;
+  }
+
+  async addAllSchemas() {
+    this.#records.clear();
+    this.#dependents.clear();
+    for await (const schemaDocument of this.#schemas.all()) {
+      this.addSchema(schemaDocument);
+    }
+  }
+
+  /**
+   * @param {SchemaDocument} schemaDocument
+   */
+  addSchema(schemaDocument) {
+    const uri = schemaDocument.textDocument.uri;
+    this.removeSchema(uri);
+    const dependent = this.#createRecord(uri);
+    for (const schemaResource of schemaDocument.schemaResources) {
+      dependent.definitions.add(schemaResource.baseUri);
+      if (schemaResource.dialectUri) {
+        this.#addDependency(dependent, schemaResource.dialectUri);
+      }
+      for (const reference of this.#schemas.references(schemaResource)) {
+        /** @type {string} */
+        const referenceValue = value(reference);
+        const referencedUri = toAbsoluteUri(resolveIri(referenceValue, schemaResource.baseUri));
+        this.#addDependency(dependent, referencedUri);
+      }
+    }
+  }
+
+  /**
+   * @param {FileSystemUri} uri
+   */
+  removeSchema(uri) {
+    const record = this.#records.get(uri);
+    if (!record) {
+      return;
+    }
+    for (const dependency of record.dependencies) {
+      const dependents = this.#dependents.get(dependency);
+      dependents?.delete(uri);
+    }
+    this.#records.delete(uri);
+  }
+
+  /**
+   * @param {FileEvent[]} changes
+   */
+  async updateSchemas(changes) {
+    for (const change of changes) {
+      switch (change.type) {
+        case FileChangeType.Created:
+        case FileChangeType.Changed: {
+          const document = await this.#schemas.get(change.uri);
+          this.addSchema(document);
+          break;
+        }
+        case FileChangeType.Deleted: {
+          this.removeSchema(change.uri);
+          break;
+        }
+      }
+    }
   }
 
   /**
@@ -139,19 +180,14 @@ export class Dependencies {
    * @param {FileSystemUri} uri
    * @returns {DependencyRecord}
    */
-  #getOrCreateRecord(uri) {
-    let dependencyRecord = this.#records.get(uri);
-
-    if (!dependencyRecord) {
-      dependencyRecord = {
-        uri,
-        dependencies: new Set(),
-        definitions: new Set([uri])
-      };
-      this.#records.set(uri, dependencyRecord);
-    }
-
-    return dependencyRecord;
+  #createRecord(uri) {
+    const record = {
+      uri,
+      dependencies: new Set(),
+      definitions: new Set([uri])
+    };
+    this.#records.set(uri, record);
+    return record;
   }
 
   /**

--- a/language-server/src/services/dependencies.js
+++ b/language-server/src/services/dependencies.js
@@ -1,0 +1,98 @@
+import { resolveIri, toAbsoluteUri } from "../util/util.js";
+import { value } from "../model/schema-node.js";
+
+/**
+ * @import { Server } from "./server.js";
+ * @import { Schemas } from "./schemas.js";
+ */
+
+/**
+ * @typedef {Object} DependencyRecord
+ * @property {string} uri
+ * @property {Set<string>} dependencies
+ * @property {Set<string>} dependents
+ */
+
+export class Dependencies {
+  #server;
+  #schemas;
+  /** @type {Map<string, DependencyRecord>} */
+  #records;
+
+  /**
+   * @param {Server} server
+   * @param {Schemas} schemas
+   */
+  constructor(server, schemas) {
+    this.#server = server;
+    this.#schemas = schemas;
+    this.#records = new Map();
+  }
+
+  async build() {
+    this.#server.console.log("Extracting Dependencies");
+    this.#records.clear();
+
+    for await (const schemaDocument of this.#schemas.all()) {
+      const uri = schemaDocument.textDocument.uri;
+      const dependent = this.#getOrCreateRecord(uri);
+      for (const schemaResource of schemaDocument.schemaResources) {
+        if (schemaResource.dialectUri) {
+          this.#addDependencyIfLocal(dependent, schemaResource.dialectUri);
+        }
+        for (const reference of this.#schemas.references(schemaResource)) {
+          /** @type {string} */
+          const referenceValue = value(reference);
+          const referencedUri = toAbsoluteUri(resolveIri(referenceValue, schemaResource.baseUri));
+          this.#addDependencyIfLocal(dependent, referencedUri);
+        }
+      }
+    }
+  }
+
+  /**
+   * @param {DependencyRecord} dependent
+   * @param {string} dependencyUri
+   */
+  #addDependencyIfLocal(dependent, dependencyUri) {
+    // NOTE: Tracks only local filesystem schemas.
+    // If a schema URI (e.g https://...) does not have a corresponding document,
+    // we can't resolve its path, we can't watch it for changes, so tracking it adds no value.
+    const dependencyDocument = this.#schemas.getBySchemaUri(dependencyUri);
+    if (!dependencyDocument) {
+      return;
+    }
+    const localDependencyUri = dependencyDocument.textDocument.uri;
+    const dependency = this.#getOrCreateRecord(localDependencyUri);
+    dependent.dependencies.add(localDependencyUri);
+    dependency.dependents.add(dependent.uri);
+  }
+
+  /**
+   * @param {string} uri
+   * @returns {DependencyRecord}
+   */
+  #getOrCreateRecord(uri) {
+    let dependencyRecord = this.#records.get(uri);
+
+    if (!dependencyRecord) {
+      dependencyRecord = {
+        uri,
+        dependencies: new Set(),
+        dependents: new Set()
+      };
+      this.#records.set(uri, dependencyRecord);
+    }
+
+    return dependencyRecord;
+  }
+
+  print() {
+    for (const [key, value] of this.#records) {
+      const dependencies = value.dependencies;
+      for (const dependency of dependencies) {
+        this.#server.console.log(`${key} -> ${dependency}`);
+      }
+    }
+  }
+}

--- a/language-server/src/services/schemas-neovim.test.ts
+++ b/language-server/src/services/schemas-neovim.test.ts
@@ -5,7 +5,6 @@ import { PublishDiagnosticsNotification } from "vscode-languageserver";
 
 describe("Feature - workspace (neovim)", () => {
   let client: TestClient;
-  let documentUriA: string;
   let documentUriB: string;
 
   beforeAll(async () => {
@@ -20,7 +19,7 @@ describe("Feature - workspace (neovim)", () => {
       }
     });
 
-    documentUriA = await client.writeDocument("./subjectA.schema.json", `{ "$schema": "https://json-schema.org/draft/2020-12/schema" }`);
+    await client.writeDocument("./subjectA.schema.json", `{ "$schema": "https://json-schema.org/draft/2020-12/schema" }`);
     documentUriB = await client.writeDocument("./subjectB.schema.json", `{ "$schema": "https://json-schema.org/draft/2020-12/schema" }`);
   });
 
@@ -37,7 +36,7 @@ describe("Feature - workspace (neovim)", () => {
     });
   });
 
-  test("a change to a watched file should validate the workspace", { retry: 3 }, async () => {
+  test("a change to a watched file should validate the file", { retry: 3 }, async () => {
     const schemaUris: string[] = [];
 
     client.onNotification(PublishDiagnosticsNotification.type, (params) => {
@@ -46,7 +45,7 @@ describe("Feature - workspace (neovim)", () => {
 
     await client.writeDocument("./subjectB.schema.json", `{ "$schema": "https://json-schema.org/draft/2020-12/schema" }`);
 
-    expect(schemaUris).to.eql([documentUriA, documentUriB]);
+    expect(schemaUris).to.eql([documentUriB]);
   });
 
   test.todo("changing the workspace folders should validate the workspace", () => {

--- a/language-server/src/services/schemas.test.ts
+++ b/language-server/src/services/schemas.test.ts
@@ -45,7 +45,7 @@ describe("JSON Schema Language Server", () => {
     expect(await diagnostics).to.equal(documentUriA);
   });
 
-  test("a change to a watched file should validate the workspace", async () => {
+  test("a change to a watched file should validate the file", async () => {
     const schemaUris: string[] = [];
 
     client.onNotification(PublishDiagnosticsNotification.type, (params) => {
@@ -54,7 +54,7 @@ describe("JSON Schema Language Server", () => {
 
     await client.writeDocument("./subjectB.schema.json", `{ "$schema": "https://json-schema.org/draft/2020-12/cshema" }`);
 
-    expect(schemaUris).to.eql([documentUriA, documentUriB]);
+    expect(schemaUris).to.eql([documentUriB]);
   });
 
   test.todo("changing the workspace folders should validate the workspace", () => {


### PR DESCRIPTION
### Description
Closes #17
This PR implements incremental validation. The server now tracks the dependencies of the workspace and revalidates only the set of schemas affected by a change.

### Key Changes
1. Implemented the `Dependencies` service, which is responsible for tracking the dependencies of the workspace and computing which schemas are affected by each change.
2. Updated `validate-workspace.js` to pass all changes to the `Dependencies` service and revalidate only the returned schemas instead of all the schemas in the workspace.
3. Updated `build-server.js` to instantiate the `Dependencies` service and pass it to the `ValidateWorkspace` feature.
4. Updated existing test expectations to consider the incremental validation.
5. Added `validate-workspace.test.ts` and implemented some integration tests to verify the incremental validation functionality.

### Implementation Details
The `Dependencies` service stores a `DependencyRecord` for each schema that exists in the workspace. The `DependencyRecord` stores a `Set` of all its dependencies and a `Set` of all of its definitions (`uri` and the provided `$id`s). The `Dependencies` service also stores a `dependents` `Map` to easily find the dependents of a file when it is edited. Although a `DependencyRecord` indicates that a schema exists in the workspace, this is not true for the `dependents` `Map` because an existing schema may reference a schema that does not exist in the workspace (yet).

When the workspace is changed, the `ValidateWorkspaceFeature` calls `Dependencies.sync` and passes the changes. Then the `Dependencies` service gets updated and the affected schemas are returned to be validated. If the changes are empty, it is considered a full dependencies discovery, so the `Dependencies` service clears its internal state and starts from scratch returning all the schemas in the workspace. Otherwise it gets updated with the changes and returns only the affected schemas.

To find the affected schemas for a change, first we need to retrieve the `DependencyRecord` for the changed schema, which is easy because the dependency records are stored in a `Map` with their `uri`s as keys. From the `DependencyRecord` we can get all its handles from the `definitions` `Set`. Using these handles as indexes to the `dependents` `Map` we can get all its direct dependents. The `Dependencies` service uses this logic recursively, while checking if a node is already visited to avoid infinite loops. Also, the `uri` of the changed file itself is added to the `Set` of the affected files. When a change occurs, the affected files actually need to be computed **twice**, once with the old workspace state and once with the current one. This is necessary because of 2 edge cases:
1. The introduced changes cause a schema to stop providing a definition. This can happen when a file is deleted so its `uri` and its `$id`s no longer exist. Or when it is changed and its provided `$id`s changed. If someone depended on this schema and the affected schemas were computed with the new workspace image, we would miss that.
2. The introduced changes cause a schema to provide a definition that was previously missing. This can happen when a file is added so its `uri` and its `$id`s become available. Or when it's changed and its provided `$id`s changed. If a schema depended on the previously missing schema and the affected schemas were computed based on the previous image we would miss that.

The `Dependencies` service is also incrementally updated:
1. If a schema is deleted, its `DependencyRecord` is removed from the `records` and its `uri` is removed from the `dependents` values.
2. If a schema is added, a `DependencyRecord` for this schema is created and its `uri` is added to the `dependents` values for each of its dependencies.
3. If a schema is changed, it is considered that the schema was deleted and added.