### PR TITLE
Exclude sourcemaps and dev files from packaged VSIX

### DIFF
--- a/vscode/.vscodeignore
+++ b/vscode/.vscodeignore
@@ -1,9 +1,5 @@
-node_modules/
-src/
-dist/
-scratch/
-*.swp
-*.swo
-.vimrc
+out/**/*.map
+node_modules/**
+src/**
+tsconfig.json
 .gitignore
-TODO


### PR DESCRIPTION
Excludes sourcemaps and unnecessary dev files (`node_modules`, `src`, `tsconfig.json`) from the packaged VSIX, per discussion in #2.

Note: adding just `out/**/*.map` to `.vscodeignore` isn't sufficient on its own providing any `.vscodeignore` file disables `vsce`'s implicit default excludes, which actually caused the VSIX to balloon to 337 files (664KB) by including `node_modules` and `src`. This PR excludes those explicitly as well.

Before: 8 files, 173KB (no `.vscodeignore`, but no protection against stale `.map` files if `out/` isn't cleaned before packaging)
After: 7 files, 173KB same size, but now safe against leftover sourcemaps from local `npm run build` (which uses `--sourcemap` for F5 debugging).

Tested: clean rebuild, installed the resulting VSIX in a fresh VSCode window, confirmed the language server starts and validates a schema file correctly with no errors.

Related to #2.